### PR TITLE
Utilize Dartscss over sass-rails modernization of tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 
 # Ignore SimpleCov test coverage metrics
 /coverage
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'bootstrap'
 gem 'devise'
 
 # Use Sass to process CSS
-gem "sassc-rails"
+gem "dartsass-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     debug (1.6.1)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
@@ -157,6 +160,8 @@ GEM
     geocoder (1.8.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.23.4-arm64-darwin)
+    google-protobuf (3.23.4-x86_64-linux)
     guard (2.18.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -245,6 +250,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.7-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -307,6 +314,9 @@ GEM
     rexml (3.2.5)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sass-embedded (1.64.1)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -368,6 +378,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -379,6 +390,7 @@ DEPENDENCIES
   bootstrap
   capybara
   chartkick (~> 5.0)
+  dartsass-rails
   debug
   devise
   figaro
@@ -392,7 +404,6 @@ DEPENDENCIES
   phonelib
   puma (~> 5.0)
   rails (~> 7.0.3)
-  sassc-rails
   selenium-webdriver
   simplecov
   sprockets-rails

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails dartsass:watch

--- a/README.md
+++ b/README.md
@@ -121,11 +121,12 @@ To set this application up locally:
 * If you need more information on setting up PostgreSQL with rails, see [here](https://www.theodinproject.com/lessons/ruby-on-rails-installing-postgresql)
 * Fork the repository and copy SSH key
 * `git clone <'SSH Key'>` to download application locally
-* `bundle install` to install gems (you may have to change gem 'sassc-rails' to gem 'sassc', "~> 2.1.0")
+* `bundle install` to install gems 
 * `bundle exec figaro install`
 * Add your PostgreSQL database username and database password to `config/application.yml` as ENV variables e.g., `DATABASE_USERNAME: "username"` `DATABASE_PASSWORD: "password`
 * `rails db:setup` to create the database, load the schema, and load seed data
-* `rails s` to run the local server
+* `gem install foreman` to handle processes
+* `bin/dev` to run the local server
 * `localhost:3000` in web browser to access the application
 
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link_tree ../builds

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,6 @@
  @import "bootstrap";
  @import url('https://fonts.googleapis.com/css2?family=Titillium+Web:ital,wght@0,300;0,400;0,600;1,400&display=swap');
 
-
  *, h1, h2, h3, h4, h5, p, a {
   margin: 0;
   padding: 0;

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
### Describe your change in plain English.

This PR replaces `sass-rails` with `dartsass-rails` so that we can use a more future-proof (up to date) way of transpiling scss in rails. In addition, this adds the use of `foreman` to handle the processes for starting the server and re-compile changes made on the sass files.

To test you should follow the updated README instructions:
- Run `gem install foreman`
- And use `bin/dev` instead of rails s to start your server

### Link to the issue

N/A