### PR TITLE
Fix n+1 on /adoptable_pets

### DIFF
--- a/app/controllers/adoptable_pets_controller.rb
+++ b/app/controllers/adoptable_pets_controller.rb
@@ -2,7 +2,7 @@ class AdoptablePetsController < ApplicationController
 
   # outer left join on Pet and Adoption
   def index
-    @pets = Pet.where.missing(:adoption)
+    @pets = Pet.includes(:adopter_applications, images_attachments: :blob).where.missing(:adoption)
   end
 
   def show


### PR DESCRIPTION
### Describe your change in plain English.

These 2 queries have N+1s
`AdopterApplication Load (0.1ms)  SELECT "adopter_applications".* FROM "adopter_applications" WHERE "adopter_applications"."pet_id" = $1  [["pet_id", 8]]`

`ActiveStorage::Attachment Exists? (0.2ms)  SELECT 1 AS one FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = $1 AND "active_storage_attachments"."record_type" = $2 AND "active_storage_attachments"."name" = $3 LIMIT $4  [["record_id", 9], ["record_type", "Pet"], ["name", "images"], ["LIMIT", 1]]`

The latter is using a `has_many_attached`, so we have to name the eager load slightly differently https://blog.saeloun.com/2020/03/06/eagerload-active-storage-models/

### Link to the issue

No issue required per @edwinthinks 