### PR TITLE
Require Faker in seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-# Seed data
+require 'faker'
 
 @organization = Organization.create!(
   name: 'placeholder',


### PR DESCRIPTION
### Describe your change in plain English.

I was trying to reset the database (`bin/rails db:reset`), but I was getting an error due to Faker being used in the seeds file. It is not `require`d anywhere in the seeds file, so this fixes that.