### PR TITLE
Add `standard` to CI

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -44,3 +44,15 @@ jobs:
       # Add or replace test runners here
       - name: Run tests
         run: bin/rake
+  standard:
+    name: Standard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@0a29871fe2b0200a17a4497bae54fe5df0d973aa # v1.115.3
+        with:
+          bundler-cache: true
+      - name: Run Standard
+        run: bundle exec standardrb


### PR DESCRIPTION
### Describe your change in plain English.

This PR runs [`standard`](https://github.com/standardrb/standard) as part of our GitHub CI

### Link to the issue

https://github.com/rubyforgood/pet-rescue/issues/50