### PR TITLE
Fix static_pages_test

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,8 +2,7 @@
 <header class="masthead">
   <div class="container">
     <h1 class='mb-4'>
-      We rescue pets in Baja, Mexico and rehome them with adopters in 
-      Canada and America
+      We rescue pets in Baja, Mexico and rehome them with adopters in Canada and America
     </h1>
     <%= link_to "Browse #{Pet.all_unadopted_pets.count} Pets", 
                 adoptable_pets_path, 

--- a/test/integration/static_pages_test.rb
+++ b/test/integration/static_pages_test.rb
@@ -4,8 +4,7 @@ class StaticPagesTest < ActionDispatch::IntegrationTest
   test "Home page can be accessed" do
     get "/"
     assert_response :success
-    assert_select "h1", 'We rescue pets in Baja, Mexico and rehome them with adopters in
-      Canada and America'
+    assert_select "h1", "We rescue pets in Baja, Mexico and rehome them with adopters in Canada and America"
   end
 
   test "Account select can be accessed" do


### PR DESCRIPTION
Not sure why it's broken without this change, but this is the error we're seeing

```
<We rescue pets in Baja, Mexico and rehome them with adopters in
      Canada and America> expected but was
<We rescue pets in Baja, Mexico and rehome them with adopters in
      Canada and America>..
```

### Describe your change in plain English.

### Link to the issue