### PR TITLE
Install brakeman gem to analyze for security vulnerabilities

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -67,4 +67,4 @@ jobs:
         with:
           bundler-cache: true
       - name: Run Brakeman
-        run: brakeman
+        run: bundle exec brakeman

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -56,3 +56,15 @@ jobs:
           bundler-cache: true
       - name: Run Standard
         run: bundle exec standardrb
+  brakeman:
+    name: Brakeman
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@0a29871fe2b0200a17a4497bae54fe5df0d973aa # v1.115.3
+        with:
+          bundler-cache: true
+      - name: Run Brakeman
+        run: brakeman

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,9 @@ group :development, :test do
 
   # Linting
   gem "standard"
+
+  # Analysis for security vulnerabilities
+  gem "brakeman"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 2.11.5, < 3)
       sassc-rails (>= 2.0.0)
+    brakeman (6.0.1)
     builder (3.2.4)
     capybara (3.37.1)
       addressable
@@ -442,6 +443,7 @@ DEPENDENCIES
   better_errors (~> 2.9, >= 2.9.1)
   bootsnap
   bootstrap
+  brakeman
   capybara
   chartkick (~> 5.0)
   dartsass-rails


### PR DESCRIPTION
### Describe your change in plain English.

[Installs `brakeman`](https://brakemanscanner.org/docs/quickstart/) and runs it on CI

If Brakeman detects warnings, it'll exit with a non-zero exit code. This should cause the CI test to fail when necessary.

### Link to the issue

Closes https://github.com/rubyforgood/pet-rescue/issues/51