### PR TITLE
Remove fixture files after tests are run

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,5 +26,6 @@ class ActiveSupport::TestCase
   def after_teardown
     super
     FileUtils.rm_rf(ActiveStorage::Blob.service.root)
+    FileUtils.rm_rf(ActiveStorage::Blob.services.fetch(:test_fixtures).root)
   end
 end


### PR DESCRIPTION
### Describe your change in plain English.

Those with a keen eye may have noticed this folder getting bigger & bigger as tests are run: `tmp/storage_fixtures`

In the integration tests `org_pets_test.rb`, there are tests that use these attachment fixtures regarding uploading/deleting images.

What this commit does is clean the files up after all the tests are run, essentially wiping the `storage_fixtures` folder altogether, instead of adding fixture files to that folder indefinitely.