### PR TITLE
Remove unique index on pet name

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -18,7 +18,6 @@
 #
 # Indexes
 #
-#  index_pets_on_name             (name) UNIQUE
 #  index_pets_on_organization_id  (organization_id)
 #
 # Foreign Keys

--- a/db/migrate/20230729141917_remove_unique_index_on_pet_name.rb
+++ b/db/migrate/20230729141917_remove_unique_index_on_pet_name.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexOnPetName < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :pets, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_210215) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_29_141917) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -177,7 +177,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_210215) do
     t.boolean "application_paused", default: false
     t.integer "pause_reason", default: 0
     t.integer "age_unit", default: 0
-    t.index ["name"], name: "index_pets_on_name", unique: true
     t.index ["organization_id"], name: "index_pets_on_organization_id"
   end
 

--- a/test/fixtures/pets.yml
+++ b/test/fixtures/pets.yml
@@ -18,7 +18,6 @@
 #
 # Indexes
 #
-#  index_pets_on_name             (name) UNIQUE
 #  index_pets_on_organization_id  (organization_id)
 #
 # Foreign Keys


### PR DESCRIPTION
We removed the ActiveRecord validation in https://github.com/rubyforgood/pet-rescue/pull/58 but not the database constraint. This PR removes the DB constraint too.

One consequence is database seeding could fail due to Faker generating the same name.