### PR TITLE
Adoption: Add vaccine reminder mailer

### DIFF
--- a/app/mailers/match_mailer.rb
+++ b/app/mailers/match_mailer.rb
@@ -1,0 +1,11 @@
+class MatchMailer < ApplicationMailer
+  def checklist_reminder(match)
+    @match = match
+
+    @adopter_account = match.adopter_account
+    @user = @adopter_account.user
+    @pet = match.pet
+
+    mail to: @user.email, subject: "#{@pet.name}'s Checklist Reminder"
+  end
+end

--- a/app/models/adoption.rb
+++ b/app/models/adoption.rb
@@ -21,4 +21,10 @@
 class Adoption < ApplicationRecord
   belongs_to :pet
   belongs_to :adopter_account
+
+  after_create_commit :send_checklist_reminder
+
+  def send_checklist_reminder
+    MatchMailer.checklist_reminder(self).deliver_later
+  end
 end

--- a/app/views/match_mailer/checklist_reminder.html.erb
+++ b/app/views/match_mailer/checklist_reminder.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Congrats on <%= @pet.name %>'s adoption!</h1>
+
+    <p>Hope everything's going well! This is just a reminder to make sure <%= @pet.name %>'s vaccinations are up to date.</p>
+
+    <p>Have a great day!</p>
+  </body>
+</html>

--- a/app/views/match_mailer/checklist_reminder.text.erb
+++ b/app/views/match_mailer/checklist_reminder.text.erb
@@ -1,0 +1,5 @@
+Congrats on <%= @pet.name %>'s adoption!
+
+Hope everything's going well! This is just a reminder to make sure <%= @pet.name %>'s vaccinations are up to date.
+
+Have a great day!

--- a/test/mailers/match_mailer_test.rb
+++ b/test/mailers/match_mailer_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class MatchMailerTest < ActionMailer::TestCase
+  test "checklist reminder" do
+    email = MatchMailer.checklist_reminder(adoptions(:adoption_one))
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal [adoptions(:adoption_one).adopter_account.user.email], email.to
+    assert_match(/Checklist Reminder/, email.subject)
+    assert_match(/#{adoptions(:adoption_one).pet.name}/, email.subject)
+    assert_match(/#{adoptions(:adoption_one).pet.name}/, email.body.encoded)
+  end
+end

--- a/test/mailers/previews/match_mailer_preview.rb
+++ b/test/mailers/previews/match_mailer_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/match_mailer
+class MatchMailerPreview < ActionMailer::Preview
+  def checklist_reminder
+    MatchMailer.checklist_reminder(Adoption.first)
+  end
+end


### PR DESCRIPTION
### Describe your change in plain English.

Send an email to the adopter regarding their Pet's vaccines when an adoption has been made

https://github.com/rubyforgood/pet-rescue/assets/20099646/60857067-7a8f-4e28-9223-42bfd7458860

http://localhost:3000/rails/mailers/match_mailer/checklist_reminder

### Link to the issue

https://github.com/rubyforgood/pet-rescue/issues/82

This will later be improved upon in https://github.com/rubyforgood/pet-rescue/issues/83