### PR TITLE
Removed ability to create staff acount

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -6,7 +6,6 @@ class RegistrationsController < Devise::RegistrationsController
   def new
     build_resource({})
     resource.build_adopter_account
-    resource.build_staff_account
     respond_with resource
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -48,12 +48,7 @@ class RegistrationsController < Devise::RegistrationsController
   def send_email
     return unless resource.id
 
-    if resource.adopter_account
-      SignUpMailer.with(user: resource).adopter_welcome_email.deliver_now
-    else
-      SignUpMailer.with(user: resource).staff_welcome_email.deliver_now
-      SignUpMailer.with(user: resource).admin_notification_new_staff.deliver_now
-    end
+    SignUpMailer.with(user: resource).adopter_welcome_email.deliver_now
   end
 end
 

--- a/app/views/adoptable_pets/show.html.erb
+++ b/app/views/adoptable_pets/show.html.erb
@@ -146,7 +146,7 @@
                   <h4 class="mb-4 mt-3">
                     Create an account to apply for this pet
                   </h4>
-                  <%= link_to 'Create Account', account_select_path , 
+                  <%= link_to 'Adopt', new_user_registration_path ,
                       class: 'custom-btn-pink mb-2' %>
                   <p>
                     <%= link_to 'Log in', new_user_session_path %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,97 +10,72 @@
 </header>
 
 <section class="pb-5" id="registration_new">
-  <!--main section-->
-  <!-- progress bar-->
-  <% if params[:account_type] == 'adopter'%>
-    <div class="container">  
-      <%= render partial: 'shared/progress_bar', locals: { page: 'account' } %>
-    </div>
-  <% end %>
+  <div class='container'>
+    <div class="row">
+      <div class="col-md-6 mx-auto card p-5">
+        <%= form_for(resource, as: resource_name,
+                     url: registration_path(resource_name)) do |f| %>
 
-    <!--form-->
-    <div class='container'>
-      <% if params[:account_type] == 'staff' %>
-        <% resource.build_staff_account if resource.staff_account.nil? %>
-      <% else %>
-        <% resource.build_adopter_account if resource.adopter_account.nil? %>
-      <% end %>
-      <div class="row">
-        <div class="col-md-6 mx-auto card p-5">
-          <%= form_for(resource, as: resource_name, 
-                                 url: registration_path(resource_name)) do |f| %>
-            
-            <%= render "devise/shared/error_messages", resource: resource %>
+          <%= render "devise/shared/error_messages", resource: resource %>
 
-              <% if params[:account_type] == 'staff' %>
-                <%= f.fields_for :staff_account do |fields| %>
-                  <%= fields.hidden_field :user_id %>
-              <% end %>
-              <% else %>
-              <%= f.fields_for :adopter_account do |fields| %>
-                  <%= fields.hidden_field :user_id %>
-              <% end %>
-              <% end %>
-            
-            <div class="form-group mb-3 bigger">
-              <%= f.label :email, 'Email*'%><br />
-              <%= f.email_field :email, 
-                                autofocus: true,
-                                required: true,
-                                autocomplete: "email", class: 'form-control' %>
-            </div>
+          <div class="form-group mb-3 bigger">
+            <%= f.label :email, 'Email*'%><br />
+            <%= f.email_field :email,
+                              autofocus: true,
+                              required: true,
+                              autocomplete: "email", class: 'form-control' %>
+          </div>
 
-            <div class="form-group mb-3 bigger">
-              <%= f.label :first_name, 'First Name*' %><br />
-              <%= f.text_field :first_name, required: true, class: 'form-control' %>
-            </div>
+          <div class="form-group mb-3 bigger">
+            <%= f.label :first_name, 'First Name*' %><br />
+            <%= f.text_field :first_name, required: true, class: 'form-control' %>
+          </div>
 
-            <div class="form-group mb-3 bigger">
-              <%= f.label :last_name, 'Last Name*' %><br />
-              <%= f.text_field :last_name, required: true, class: 'form-control' %>
-            </div>
+          <div class="form-group mb-3 bigger">
+            <%= f.label :last_name, 'Last Name*' %><br />
+            <%= f.text_field :last_name, required: true, class: 'form-control' %>
+          </div>
 
-            <div class="form-group mb-3 bigger">
-              <%= f.label :password, 'Password*' %>
-              <% if @minimum_password_length %>
+          <div class="form-group mb-3 bigger">
+            <%= f.label :password, 'Password*' %>
+            <% if @minimum_password_length %>
               <em>(<%= @minimum_password_length %> characters minimum)</em>
-              <% end %><br />
-              <%= f.password_field :password,
-                                  required: true,
-                                  autocomplete: "new-password", 
-                                  class: 'form-control' %>
-            </div>
+            <% end %><br />
+            <%= f.password_field :password,
+                                 required: true,
+                                 autocomplete: "new-password",
+                                 class: 'form-control' %>
+          </div>
 
-            <div class="form-group mb-3 bigger">
-              <%= f.label :password_confirmation, 'Password Confirmation*' %>
-              <%= f.password_field :password_confirmation,
-                                  required: true,
-                                  autocomplete: "new-password", 
-                                  class: 'form-control' %>
-            </div>
+          <div class="form-group mb-3 bigger">
+            <%= f.label :password_confirmation, 'Password Confirmation*' %>
+            <%= f.password_field :password_confirmation,
+                                 required: true,
+                                 autocomplete: "new-password",
+                                 class: 'form-control' %>
+          </div>
 
-            <div class="form-group mb-3 bigger">
-              <%= f.check_box :tos_agreement, required: true,
-                              class: 'me-2' %>
-              <%= f.label :tos_agreement, '*I agree to the' %>
-              <%= link_to 'Terms and Conditions', terms_and_conditions_path, 
-                  target: '_blank', class: 'text-decoration-none' %>
-              <span>& </span>
-              <%= link_to 'Privacy Policy', privacy_policy_path, 
-                  target: '_blank', class: 'text-decoration-none' %>
-                  <span>& </span>
-              <%= link_to 'Cookie Policy', cookie_policy_path, 
-                  target: '_blank', class: 'text-decoration-none' %>
-            </div>
+          <div class="form-group mb-3 bigger">
+            <%= f.check_box :tos_agreement, required: true,
+                            class: 'me-2' %>
+            <%= f.label :tos_agreement, '*I agree to the' %>
+            <%= link_to 'Terms and Conditions', terms_and_conditions_path,
+                        target: '_blank', class: 'text-decoration-none' %>
+            <span>& </span>
+            <%= link_to 'Privacy Policy', privacy_policy_path,
+                        target: '_blank', class: 'text-decoration-none' %>
+            <span>& </span>
+            <%= link_to 'Cookie Policy', cookie_policy_path,
+                        target: '_blank', class: 'text-decoration-none' %>
+          </div>
 
-            <div class="actions">
-              <%= f.submit "Create Account", class: 'btn btn-outline-dark mb-3 bigger', 
-                           data: { turbo: false } %>
-            </div>
-          <% end %>
-          <%= render "devise/shared/links" %>
-        </div><!--col-->
-      </div><!--row-->
-    </div><!--container-->
+          <div class="actions">
+            <%= f.submit "Create Account", class: 'btn btn-outline-dark mb-3 bigger',
+                         data: { turbo: false } %>
+          </div>
+        <% end %>
+        <%= render "devise/shared/links" %>
+      </div><!--col-->
+    </div><!--row-->
+  </div><!--container-->
 </section>
-

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", account_select_path %>
+  <%= link_to "Sign up", new_user_registration_path %>
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,7 +70,7 @@
           <ul class="navbar-nav mb-md-0">
             <% unless user_signed_in? %>
               <li class="nav-item navbar-dark">
-                <%= link_to 'Create Account', account_select_path, 
+                <%= link_to 'Adopt', new_user_registration_path,
                     class: 'btn-outline-light btn me-3 navbar-margin-bottom bigger' %>
               </li>
               <li class="nav-item navbar-dark">

--- a/app/views/static_pages/about_us.html.erb
+++ b/app/views/static_pages/about_us.html.erb
@@ -34,7 +34,7 @@
         <br>
         <div class='d-flex flex-column align-items-center'>
           <h3 class='mb-4 mt-3'>Become an adopter now!</h3>
-          <%= link_to 'Create Account', account_select_path , 
+          <%= link_to 'Adopt', new_user_registration_path ,
                       class: 'custom-btn-pink text-center' %>
         </div>
       </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -141,7 +141,7 @@
         <div class="col-8 offset-2 border p-5 shadow-sm 
                     rounded bg-white">
           <h3 class='mb-4'>Become an adopter now!</h3>
-          <%= link_to 'Create Account', account_select_path , 
+          <%= link_to 'Create Account', new_user_registration_path ,
                       class: 'custom-btn-pink' %>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,6 @@ Rails.application.routes.draw do
   get "/terms_and_conditions", to: "static_pages#terms_and_conditions"
   get "/cookie_policy", to: "static_pages#cookie_policy"
 
-  get "/account_select", to: "static_pages#account_select"
   get "/profile_review/:id", to: "profile_reviews#show", as: "profile_review"
 
   get "/adoptable_pets", to: "adoptable_pets#index"

--- a/test/integration/adoptable_pet_show_test.rb
+++ b/test/integration/adoptable_pet_show_test.rb
@@ -10,7 +10,7 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
     get "/adoptable_pets/#{@pet_id}"
     assert_response :success
     assert_select "h4", "Create an account to apply for this pet"
-    assert_select "a", "Create Account"
+    assert_select "a", "Adopt"
   end
 
   test "adopter without a profile sees complete my profile prompt and link" do

--- a/test/integration/adopter_signup_test.rb
+++ b/test/integration/adopter_signup_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class AdopterSignupTest < ActionDispatch::IntegrationTest
-  test "selecting adopter sends correct param" do
-    get "/account_select"
-    assert_response :success
-  end
-end

--- a/test/integration/static_pages_test.rb
+++ b/test/integration/static_pages_test.rb
@@ -7,12 +7,6 @@ class StaticPagesTest < ActionDispatch::IntegrationTest
     assert_select "h1", "We rescue pets in Baja, Mexico and rehome them with adopters in Canada and America"
   end
 
-  test "Account select can be accessed" do
-    get "/account_select"
-    assert_response :success
-    assert_select "h1", "Sign Up"
-  end
-
   test "About Us page can be accessed" do
     get "/about_us"
     assert_response :success

--- a/test/integration/user_account_test.rb
+++ b/test/integration/user_account_test.rb
@@ -79,9 +79,7 @@ class UserAccountTest < ActionDispatch::IntegrationTest
     assert_equal mail[0].from.join, "bajapetrescue@gmail.com", "from email is incorrect"
     assert_equal mail[0].to.join, "abc@123.com", "to email is incorrect"
     assert_equal mail[0].subject, "Welcome to Baja Pet Rescue", "subject is incorrect"
-    assert_equal mail[1].from.join, "bajapetrescue@gmail.com", "from email is incorrect"
-    assert_equal mail[1].to.join, "wcrwater@gmail.com", "to email is incorrect"
-    assert_equal mail[1].subject, "New Staff Account", "subject is incorrect"
+
     ActionMailer::Base.deliveries = []
 
     assert_response :redirect


### PR DESCRIPTION
- Removed account_select route
- Removed the account_select shared partial
- Removed the conditionals that required account type from the new users registration view
- Changed caption and route of Create account links to 'Adopt'. They point to the  new user registration path instead of the account select path
- Removed Staff emails from the send_email method in the registrations controller
