### PR TITLE
Add birth_date to Pet and compute age dynamically

### DIFF
--- a/app/controllers/organization_pets_controller.rb
+++ b/app/controllers/organization_pets_controller.rb
@@ -62,8 +62,7 @@ class OrganizationPetsController < ApplicationController
   def pet_params
     params.require(:pet).permit(:organization_id,
       :name,
-      :age,
-      :age_unit,
+      :birth_date,
       :sex,
       :breed,
       :size,

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -65,28 +65,6 @@ class Pet < ApplicationRecord
     images.attach(attachables)
   end
 
-  # This will be approximate for multiple reasons
-  # - we aren't checking whether today's date has passed the pet's birthdate but instead calculating from duration
-  # - most birthdays entered in the system aren't exact
-  def approximate_age
-    today_in_seconds_since_unix_epoch = DateTime.current.to_i
-    pet_birth_date_in_seconds_since_unix_epoch = self.birth_date.to_i
-    pet_life_duration = ActiveSupport::Duration.build(today_in_seconds_since_unix_epoch - pet_birth_date_in_seconds_since_unix_epoch)
-
-    # years and months will be missing if they are 0, so initialize hash with 0 values and merge in the computed ones, if any
-    {years: 0, months: 0}.merge(pet_life_duration.parts.slice(:years, :months))
-  end
-
-  def approximate_age_display
-    approximate_age => {years:, months:}
-
-    years_string = years.positive? ? "#{years} years" : nil
-    months_string = months.positive? ? "#{months} months" : nil
-
-    # using compact and join will correctly handle the case when either years or months is 0
-    [years_string, months_string].compact.join(', ')
-  end
-
   # all pets under an organization
   def self.org_pets(staff_org_id)
     Pet.where(organization_id: staff_org_id)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -4,7 +4,7 @@
 #
 #  id                 :bigint           not null, primary key
 #  application_paused :boolean          default(FALSE)
-#  birth_date         :datetime
+#  birth_date         :datetime         not null
 #  breed              :string
 #  description        :text
 #  name               :string

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -3,8 +3,6 @@
 # Table name: pets
 #
 #  id                 :bigint           not null, primary key
-#  age                :integer
-#  age_unit           :integer          default("months")
 #  application_paused :boolean          default(FALSE)
 #  birth_date         :datetime
 #  breed              :string
@@ -34,8 +32,6 @@ class Pet < ApplicationRecord
 
   validates :name, presence: true
   validates :birth_date, presence: true
-  #validates :age, presence: true
-  #validates :age_unit, presence: true
   validates :size, presence: true
   validates :breed, presence: true
   validates :sex, presence: true
@@ -47,8 +43,6 @@ class Pet < ApplicationRecord
     limit: {max: 5, message: "- 5 maximum"},
     size: {between: 10.kilobyte..1.megabytes,
            message: "size must be between 10kb and 1Mb"}
-
-  enum :age_unit, [:months, :years]
 
   enum :pause_reason, [:not_paused,
     :opening_soon,
@@ -64,12 +58,6 @@ class Pet < ApplicationRecord
     Pet.pause_reasons.keys.map do |reason|
       [reason.titleize, reason]
     end.drop(1)
-  end
-
-  def self.list_age_units
-    Pet.age_units.keys.map do |unit|
-      [unit.titleize, unit]
-    end
   end
 
   # active storage: using.attach for appending images per rails guide

--- a/app/views/adoptable_pets/index.html.erb
+++ b/app/views/adoptable_pets/index.html.erb
@@ -31,7 +31,7 @@
                     <% end %>
                   </h3>
                 <p class="card-text m-0 bigger">
-                  Age: <%= "#{pet.age}" " #{pet.age_unit}" %>
+                  Age: <%= "#{pet.approximate_age_display}" %>
                 </p>
                 <p class="card-text bigger">
                   Breed: <%= pet.breed %>

--- a/app/views/adoptable_pets/index.html.erb
+++ b/app/views/adoptable_pets/index.html.erb
@@ -31,7 +31,7 @@
                     <% end %>
                   </h3>
                 <p class="card-text m-0 bigger">
-                  Age: <%= "#{pet.approximate_age_display}" %>
+                  Age: <%= time_ago_in_words(pet.birth_date) %>
                 </p>
                 <p class="card-text bigger">
                   Breed: <%= pet.breed %>

--- a/app/views/adoptable_pets/show.html.erb
+++ b/app/views/adoptable_pets/show.html.erb
@@ -50,7 +50,7 @@
         <div class='row mb-3'>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Age:</h5>
-            <h5><%= "#{@pet.age}" " #{@pet.age_unit}" %></h5>
+            <h5><%= "#{@pet.approximate_age_display}" %></h5>
           </div>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Sex:</h5>

--- a/app/views/adoptable_pets/show.html.erb
+++ b/app/views/adoptable_pets/show.html.erb
@@ -50,7 +50,7 @@
         <div class='row mb-3'>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Age:</h5>
-            <h5><%= "#{@pet.approximate_age_display}" %></h5>
+            <h5><%= time_ago_in_words(@pet.birth_date) %></h5>
           </div>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Sex:</h5>

--- a/app/views/organization_pets/_form.html.erb
+++ b/app/views/organization_pets/_form.html.erb
@@ -16,23 +16,13 @@
 
       <div class='form-group d-flex'>
         <div class='me-3'>
-          <%= form.label :age, class: 'mt-3' %>
-          <%= form.number_field :age, class: 'form-control' %>        
+          <%= form.label :birth_date, class: 'mt-3' %>
+          <%= form.date_select :birth_date,
+                               start_year: Date.today.year - 20,
+                               end_year: Date.today.year %>
         </div>
 
-        <div>
-          <%= form.label :age_unit, 'Unit', class: 'mt-3' %>
-          <%= form.select(:age_unit, 
-                                    Pet.list_age_units, 
-                                    {},
-                                    { class: "form-control"}) %>
-        </div>
-
-        <% pet.errors.full_messages_for(:age).each do |message| %>
-          <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-        <% end %>
-        
-        <% pet.errors.full_messages_for(:age_unit).each do |message| %>
+        <% pet.errors.full_messages_for(:birth_date).each do |message| %>
           <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
         <% end %>
       </div>

--- a/app/views/organization_pets/show.html.erb
+++ b/app/views/organization_pets/show.html.erb
@@ -46,7 +46,7 @@
         <div class='row mb-3'>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Age:</h5>
-            <h5><%= "#{@pet.approximate_age_display}" %></h5>
+            <h5><%= time_ago_in_words(@pet.birth_date) %></h5>
           </div>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Sex:</h5>

--- a/app/views/organization_pets/show.html.erb
+++ b/app/views/organization_pets/show.html.erb
@@ -46,7 +46,7 @@
         <div class='row mb-3'>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Age:</h5>
-            <h5><%= "#{@pet.age}" " #{@pet.age_unit}" %></h5>
+            <h5><%= "#{@pet.approximate_age_display}" %></h5>
           </div>
           <div class='col-md-2 mb-1'>
             <h5 style='font-weight: bold;'>Sex:</h5>

--- a/db/migrate/20230730134633_add_birthdate_to_pets.rb
+++ b/db/migrate/20230730134633_add_birthdate_to_pets.rb
@@ -1,5 +1,5 @@
 class AddBirthdateToPets < ActiveRecord::Migration[7.0]
   def change
-    add_column :pets, :birth_date, :datetime
+    add_column :pets, :birth_date, :datetime, null: false
   end
 end

--- a/db/migrate/20230730134633_add_birthdate_to_pets.rb
+++ b/db/migrate/20230730134633_add_birthdate_to_pets.rb
@@ -1,0 +1,5 @@
+class AddBirthdateToPets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :pets, :birth_date, :datetime
+  end
+end

--- a/db/migrate/20230730145336_remove_age_from_pets.rb
+++ b/db/migrate/20230730145336_remove_age_from_pets.rb
@@ -1,0 +1,6 @@
+class RemoveAgeFromPets < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :pets, :age
+    remove_column :pets, :age_unit
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,7 +195,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_30_145336) do
     t.string "name"
     t.boolean "application_paused", default: false
     t.integer "pause_reason", default: 0
-    t.datetime "birth_date"
+    t.datetime "birth_date", null: false
     t.index ["organization_id"], name: "index_pets_on_organization_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_30_134633) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_30_145336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -186,7 +186,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_30_134633) do
 
   create_table "pets", force: :cascade do |t|
     t.bigint "organization_id", null: false
-    t.integer "age"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "size"
@@ -196,7 +195,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_30_134633) do
     t.string "name"
     t.boolean "application_paused", default: false
     t.integer "pause_reason", default: 0
-    t.integer "age_unit", default: 0
     t.datetime "birth_date"
     t.index ["organization_id"], name: "index_pets_on_organization_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_29_200513) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_30_134633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -197,6 +197,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_29_200513) do
     t.boolean "application_paused", default: false
     t.integer "pause_reason", default: 0
     t.integer "age_unit", default: 0
+    t.datetime "birth_date"
     t.index ["organization_id"], name: "index_pets_on_organization_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -219,7 +219,7 @@ path = Rails.root.join("app", "assets", "images", "hero.jpg")
   pet = Pet.create!(
     organization: Organization.all.sample,
     name: Faker::Creature::Dog.name,
-    age: Faker::Number.within(range: 1..10),
+    birth_date: Faker::Date.birthday(min_age: 0, max_age: 3),
     sex: Faker::Creature::Dog.gender,
     size: Faker::Creature::Dog.size,
     breed: Faker::Creature::Dog.breed,

--- a/test/fixtures/pets.yml
+++ b/test/fixtures/pets.yml
@@ -3,8 +3,6 @@
 # Table name: pets
 #
 #  id                 :bigint           not null, primary key
-#  age                :integer
-#  age_unit           :integer          default("months")
 #  application_paused :boolean          default(FALSE)
 #  birth_date         :datetime
 #  breed              :string

--- a/test/fixtures/pets.yml
+++ b/test/fixtures/pets.yml
@@ -4,7 +4,7 @@
 #
 #  id                 :bigint           not null, primary key
 #  application_paused :boolean          default(FALSE)
-#  birth_date         :datetime
+#  birth_date         :datetime         not null
 #  breed              :string
 #  description        :text
 #  name               :string

--- a/test/fixtures/pets.yml
+++ b/test/fixtures/pets.yml
@@ -6,6 +6,7 @@
 #  age                :integer
 #  age_unit           :integer          default("months")
 #  application_paused :boolean          default(FALSE)
+#  birth_date         :datetime
 #  breed              :string
 #  description        :text
 #  name               :string
@@ -28,7 +29,7 @@
 one:
   organization: one
   name: Applications
-  age: 4
+  birth_date: <%= DateTime.current - (4.months + 15.days) %>
   breed: mix
   size: Medium (22-57 lb)
   sex: Female
@@ -38,21 +39,21 @@ one:
 pending_adoption_one:
   organization: one
   name: Deleted
-  age: 5
+  birth_date: <%= DateTime.current - (5.months + 15.days) %>
   breed: mix
   application_paused: false
 
 adopted_pet:
   organization: one
   name: Adopted
-  age: 4
+  birth_date: <%= DateTime.current - (4.months + 15.days) %>
   breed: mix
   application_paused: false
 
 paused_application:
   organization: one
   name: Paused
-  age: 4
+  birth_date: <%= DateTime.current - (4.months + 15.days) %>
   breed: mix
   size: Medium (22-57 lb)
   sex: Male
@@ -62,6 +63,6 @@ paused_application:
 pending_adoption_two:
   organization: one
   name: AppTest
-  age: 4
+  birth_date: <%= DateTime.current - (4.months + 15.days) %>
   breed: mix
   application_paused: false

--- a/test/integration/org_pets_test.rb
+++ b/test/integration/org_pets_test.rb
@@ -69,7 +69,7 @@ class OrgPetsTest < ActionDispatch::IntegrationTest
         {
           organization_id: organizations(:one).id.to_s,
           name: "TestPet",
-          age: "3",
+          birth_date: DateTime.current - (4.months + 15.days),
           sex: "Female",
           breed: "mix",
           size: "Medium (22-57 lb)",

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -7,7 +7,7 @@ class MatchTest < ActiveSupport::TestCase
     org1 = Organization.create!
     org2 = Organization.create!
     pet = Pet.create!(organization: org1,
-      name: "Harry", age: 5, size: "small", breed: "corgi", sex: "m", description: "test pet")
+      name: "Harry", birth_date: 5.years.ago, size: "small", breed: "corgi", sex: "m", description: "test pet")
     match = Match.create(pet: pet, organization_id: org2.id,
       adopter_account: adopter_accounts(:adopter_account_one))
     assert !match.valid?

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -11,8 +11,7 @@ class PetTest < ActiveSupport::TestCase
 
   context "validations" do
     should validate_presence_of(:name)
-    should validate_presence_of(:age)
-    should validate_presence_of(:age_unit)
+    should validate_presence_of(:birth_date)
     should validate_presence_of(:size)
     should validate_presence_of(:breed)
     should validate_presence_of(:sex)


### PR DESCRIPTION
Closes https://github.com/rubyforgood/pet-rescue/issues/90

Currently age is a static form field, so if a month passes in real time, the pet's age stays the same.

Ruby (https://bugs.ruby-lang.org/issues/14877) nor ActiveSupport have a
way to compute the age given a birthday and most answers online are
concerned with human ages which tend to only be in years. ~~Since it seems
like we want to include months, especially if the pet is less than 1
year old, I added a custom function for computing and display that. It
isn't technically accurate because we compute it off the duration from
today and the birthdate, but should be acceptable because birthdates in
the system will typically be approximate anyway.~~

Switched this to use https://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html#method-i-time_ago_in_words, which is still approximate but should serve our purposes. The only difference is that instead of always saying "exact" years and months, it will sometimes use "about", "almost", "over".