### PR TITLE
Begin replacing fixtures with FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,9 @@ group :development, :test do
 
   # Analysis for security vulnerabilities
   gem "brakeman"
+
+  # Creating factory instantiations in tests
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,11 @@ GEM
       capybara
       zeitwerk (>= 2)
     execjs (2.8.1)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     faker (3.2.0)
       i18n (>= 1.8.11, < 2)
     faraday (1.10.3)
@@ -478,6 +483,7 @@ DEPENDENCIES
   debug
   devise
   evil_systems (~> 1.1)
+  factory_bot_rails
   faker
   figaro
   geocoder

--- a/test/controllers/checklist_templates_controller_test.rb
+++ b/test/controllers/checklist_templates_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ChecklistTemplatesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @checklist_template = checklist_templates(:one)
+    @checklist_template = create(:checklist_template)
   end
 
   test "should get index" do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,0 +1,109 @@
+FactoryBot.define do
+  factory :adopter_account do
+    user
+  end
+
+  factory :adopter_application do
+    notes { Faker::Lorem.paragraph }
+    profile_show { [true, false].sample }
+    status { 1 }
+
+    adopter_account
+    pet
+
+    trait :adoption_pending do
+      status { 2 }
+    end
+  end
+
+  factory :adopter_profile do
+    phone_number { "250-598-8843" }
+    contact_method { "Phone" }
+    ideal_pet { "Huge and soft" }
+    lifestyle_fit { "Active" }
+    activities { "Walking and camping" }
+    alone_weekday { 3 }
+    alone_weekend { 3 }
+    experience { "Tons" }
+    contingency_plan { "Friends" }
+    shared_ownership { false }
+    housing_type { "Detached" }
+    fenced_access { true }
+    location_day { "house" }
+    location_night { "house" }
+    do_you_rent { false }
+    adults_in_home { 2 }
+    kids_in_home { 2 }
+    other_pets { false }
+    checked_shelter { true }
+    surrendered_pet { false }
+    annual_cost { "not much" }
+    visit_laventana { false }
+    referral_source { "friends" }
+
+    adopter_account
+  end
+
+  factory :checklist_template do
+    description { Faker::Lorem.paragraph }
+    name { Faker::Lorem.word }
+  end
+
+  factory :organization do
+  end
+
+  factory :pet do
+    birth_date { Faker::Date.backward(days: 7) }
+    breed { Faker::Creature::Dog.breed }
+    description { Faker::Lorem.sentence }
+    name { Faker::Creature::Dog.name }
+    sex { Faker::Creature::Dog.gender }
+    size { Faker::Creature::Dog.size }
+
+    organization
+
+    trait :adoption_pending do
+      adopter_applications { build_list(:adopter_application, 3, :adoption_pending) }
+    end
+
+    trait :application_paused do
+      application_paused { true }
+    end
+  end
+
+  factory :staff_account do
+    verified { true }
+
+    organization
+    user
+
+    trait :unverified do
+      verified { false }
+    end
+  end
+
+  factory :user do
+    email { Faker::Internet.email }
+    password { "123456" }
+    encrypted_password { Faker::Lorem.word }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    tos_agreement { true }
+
+    trait :verified_staff do
+      staff_account
+    end
+
+    trait :unverified_staff do
+      staff_account { build(:staff_account, :unverified) }
+    end
+
+    trait :adopter_with_profile do
+      adopter_account
+
+      after :create do |user|
+        create :adopter_profile, adopter_account: user.adopter_account
+      end
+    end
+  end
+end

--- a/test/integration/adoptable_pets_index_test.rb
+++ b/test/integration/adoptable_pets_index_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class AdoptablePetsIndexTest < ActionDispatch::IntegrationTest
   # all unadopted pets under all organizations
   setup do
+    @pet = create(:pet, :adoption_pending)
     @pet_count = Pet.includes(:match).where(match: {id: nil}).length
   end
 
@@ -19,6 +20,6 @@ class AdoptablePetsIndexTest < ActionDispatch::IntegrationTest
 
   test "pet name shows adoption pending if it has any applications with that status" do
     get "/adoptable_pets"
-    assert_select "h3", "#{pets(:pending_adoption_one).name} (Adoption Pending)"
+    assert_select "h3", "#{@pet.name} (Adoption Pending)"
   end
 end

--- a/test/integration/adopter_application_test.rb
+++ b/test/integration/adopter_application_test.rb
@@ -2,18 +2,19 @@ require "test_helper"
 
 class AdopterApplicationTest < ActionDispatch::IntegrationTest
   setup do
-    @pet_id = pets(:one).id
-    @paused_pet_id = pets(:paused_application).id
+    @organization = create(:organization)
+    @pet_id = create(:pet, organization: @organization).id
   end
 
   test "adopter user without profile cannot apply for pet and sees flash error" do
-    sign_in users(:adopter_without_profile)
+    user = create(:user)
+    sign_in user
     before_count = AdopterApplication.all.count
 
     post "/create_my_application",
       params: {application:
         {
-          adopter_account_id: adopter_accounts(:adopter_account_two).id,
+          adopter_account_id: user.id,
           pet_id: @pet_id
         }}
 
@@ -25,7 +26,8 @@ class AdopterApplicationTest < ActionDispatch::IntegrationTest
   end
 
   test "staff user sees flash error if they apply for a pet" do
-    sign_in users(:verified_staff_one)
+    verified_staff = create(:user, :verified_staff)
+    sign_in verified_staff
     before_count = AdopterApplication.all.count
 
     post "/create_my_application",
@@ -43,13 +45,16 @@ class AdopterApplicationTest < ActionDispatch::IntegrationTest
   end
 
   test "adopter user with profile can apply for a pet and staff receive email" do
-    sign_in users(:adopter_with_profile)
+    verified_staff = create(:staff_account, organization: @organization)
+    org_staff = create(:user, staff_account: verified_staff)
+    adopter_with_profile = create(:user, :adopter_with_profile)
+    sign_in adopter_with_profile
     before_count = AdopterApplication.all.count
 
     post "/create_my_application",
       params: {application:
         {
-          adopter_account_id: adopter_accounts(:adopter_account_one).id,
+          adopter_account_id: adopter_with_profile.adopter_account.id,
           pet_id: @pet_id
         }}
 
@@ -60,19 +65,21 @@ class AdopterApplicationTest < ActionDispatch::IntegrationTest
 
     mail = ActionMailer::Base.deliveries
     assert_equal mail[0].from.join, "bajapetrescue@gmail.com", "from email is incorrect"
-    assert_equal mail[0].to.join(" "), "testes@test.com purple@haze.com", "to email is incorrect"
+    assert_equal mail[0].to.join(" "), org_staff.email, "to email is incorrect"
     assert_equal mail[0].subject, "New Adoption Application", "subject is incorrect"
   end
 
   test "adopter user with profile cannot apply for a paused pet and sees flash error" do
-    sign_in users(:adopter_with_profile)
+    paused_pet_id = create(:pet, :application_paused).id
+    adopter_with_profile = create(:user, :adopter_with_profile)
+    sign_in adopter_with_profile
     before_count = AdopterApplication.all.count
 
     post "/create_my_application",
       params: {application:
         {
-          adopter_account_id: adopter_accounts(:adopter_account_one).id,
-          pet_id: @paused_pet_id
+          adopter_account_id: adopter_with_profile.adopter_account.id,
+          pet_id: paused_pet_id
         }}
 
     assert_response :redirect

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ require_relative "../config/environment"
 require "rails/test_help"
 
 class ActiveSupport::TestCase
+  include FactoryBot::Syntax::Methods
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)
 


### PR DESCRIPTION
### Describe your change in plain English.
This PR introduces [FactoryBot](https://github.com/thoughtbot/factory_bot_rails), which I think we'll want to move towards. I'm keeping the fixtures in the codebase for now because existing tests rely on it but over time hopefully we can replace our usage of fixtures with factories instead.

`test/integration/adopter_application_test.rb` shows a more complicated/usual example of how that may look. I don't think we should have all of our factories in one file as I do here but for now it's kind of convenient.

If this looks good I think we might as well merge it now and just keep it as an ongoing process in the background that we'll gradually replace the tests and hopefully someday soon retire the fixtures!

### Link to the issue
#126