### PR TITLE
Remove password confirmation on registration

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -18,7 +18,6 @@ class RegistrationsController < Devise::RegistrationsController
       :email,
       :password,
       :signup_role,
-      :password_confirmation,
       :tos_agreement,
       adopter_account_attributes: [:user_id],
       staff_account_attributes: [:user_id])

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -48,14 +48,6 @@
           </div>
 
           <div class="form-group mb-3 bigger">
-            <%= f.label :password_confirmation, 'Password Confirmation*' %>
-            <%= f.password_field :password_confirmation,
-                                 required: true,
-                                 autocomplete: "new-password",
-                                 class: 'form-control' %>
-          </div>
-
-          <div class="form-group mb-3 bigger">
             <%= f.check_box :tos_agreement, required: true,
                             class: 'me-2' %>
             <%= f.label :tos_agreement, '*I agree to the' %>

--- a/test/integration/user_account_test.rb
+++ b/test/integration/user_account_test.rb
@@ -40,7 +40,6 @@ class UserAccountTest < ActionDispatch::IntegrationTest
           first_name: "Foo",
           last_name: "Bar",
           password: "123456",
-          password_confirmation: "123456",
           tos_agreement: "1"
         },
                commit: "Create Account"}


### PR DESCRIPTION
### Describe your change in plain English.
Removed password confirmation on account creation.

According to the [devise docs](https://github.com/heartcombo/devise/wiki/Disable-password-confirmation-during-registration), this changes are enough to remove password confirmation. 

### Link to the issue
https://github.com/rubyforgood/pet-rescue/issues/91