### PR TITLE
Show error message when login does not work

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,6 +16,14 @@
             <h1 class="mb-1 fw-bold">Sign in</h1>
             <span>Don’t have an account? <%= link_to "Sign up", new_user_registration_path, class: 'small fw-bold' %></span>
           </div>
+
+          <div>
+            <% if flash[:alert] %>
+              <div class="alert alert-danger" role="alert">
+                <%= alert %>
+              </div>
+            <% end%>
+          </div>
           <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
             <%= f.label :email %><br />
             <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -5,21 +5,7 @@
   <body>
     <main>
       <div>
-        <% if flash[:notice] %>
-          <div class="flash-notice bigger">
-            <%= notice %>
-          </div>
-        <% end %>
-
-        <% if flash[:alert] %>
-          <div class="flash-alert bigger">
-            <%= alert %>
-          </div>
-        <% end%>
-
-        <div>
-          <%= yield %>
-        </div>
+        <%= yield %>
       </div>
     </main>
   </body>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -311,4 +311,7 @@ Devise.setup do |config|
 
   # added to prevent turbo conflict
   config.navigational_formats = ["*/*", :html, :turbo_stream]
+
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
 end


### PR DESCRIPTION
### Describe your change in plain English.

This handles the issue in #185 in which we want to inform users when their username/password is incorrect.

### Demo
<img width="801" alt="Captura de pantalla 2023-09-25 a las 18 17 07" src="https://github.com/rubyforgood/pet-rescue/assets/11335191/f533eb49-1ba2-4666-888c-e5a1c1f52bda">


### Link to the issue

#185 