### PR TITLE
Update redirection logic after login to goto dashboard if they are verified staff

### DIFF
--- a/app/controllers/concerns/organization_scopable.rb
+++ b/app/controllers/concerns/organization_scopable.rb
@@ -15,7 +15,11 @@ module OrganizationScopable
   end
 
   def after_sign_in_path_for(resource_or_scope)
-    adoptable_pets_path
+    if resource_or_scope.staff_account&.verified
+      dashboard_index_path
+    else
+      adoptable_pets_path
+    end
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/test/system/login_test.rb
+++ b/test/system/login_test.rb
@@ -4,11 +4,12 @@ class LoginTest < ApplicationSystemTestCase
   setup do
     @organization = create(:organization)
     @user = create(:user, organization: @organization)
+    StaffAccount.create!(user: @user, organization: @organization, verified: true)
     set_organization(@organization)
   end
 
   context "when logging in as a staff member" do
-    should "direct to the organization's adoptable pets page" do
+    should "direct to the organization's dashboard" do
       visit root_url
       click_on "Log In"
 
@@ -17,7 +18,7 @@ class LoginTest < ApplicationSystemTestCase
       click_on "Log in"
 
       assert current_path.include?(@user.organization.slug)
-      assert page.has_content?("Signed in successfully.")
+      assert current_path.has_content?("Dashboard")
     end
   end
 end


### PR DESCRIPTION
### Describe your change in plain English.

Adds logic to redirect verified staff to the dashboard so they are brought to management tools directly after login. Any non-verified staff are taking to the adoptable pets section.

### Demo

N/A

### How to Test
1. Goto the /alta/users/sign_in page
2. Login as staff@alta.com / 123456
3. You should be redirected to the dashboard page.

### Link to the issue

N/A