### PR TITLE
Upgrade flash messages

### DIFF
--- a/app/javascript/controllers/flash_message_controller.js
+++ b/app/javascript/controllers/flash_message_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    var toast = new bootstrap.Toast(this.element, { delay: 3500 })
+    toast.show()
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <%= render "layouts/shared/head" %>
 
   <body>
+    <%= render "layouts/shared/flash_messages" %>
     <% if Current.tenant.present? %>
       <%= render partial: "layouts/shared/navbar" %>
     <% else %>
@@ -10,24 +11,7 @@
     <% end %>
 
     <main>
-      <div>
-        <% if flash[:notice] %>
-          <div class="flash-notice bigger">
-            <%= notice %>
-          </div>
-        <% end %>
-
-        <% if flash[:alert] %>
-          <div class="flash-alert bigger">
-            <%= alert %>
-          </div>
-        <% end%>
-
-        <div>
-        
-          <%= yield %>
-        </div>
-      </div>
+      <%= yield %>
     </main>
 
     <% if Current.tenant.present? %>

--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <%= render "layouts/shared/head" %>
-
   <body>
+    <%= render "layouts/shared/flash_messages" %>
     <div id="db-wrapper">
  <!-- navbar vertical -->
   <!-- Sidebar -->
@@ -566,12 +566,12 @@
                             </div>
                             <div class="d-flex">
                             <%= yield :button %>
-                                
+
                         </div>
                     </div>
                 </div>
-                
-                
+
+
                 <%= yield %>
             </section>
         </main>

--- a/app/views/layouts/shared/_flash_messages.html.erb
+++ b/app/views/layouts/shared/_flash_messages.html.erb
@@ -1,0 +1,13 @@
+<div class="toast-container fixed-top top-0 start-50 translate-middle-x p-3">
+  <% flash.each do |type, message| %>
+    <% flash_color = type == :alert ? 'danger' : 'primary' %>
+    <div data-controller="flash-message" class="toast align-items-center text-white bg-<%= flash_color %> border-0" role="status" aria-live="polite" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">
+          <%= message %>
+        </div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
### Describe your change in plain English.
Upgrade flash messages on every layout except the devise. It uses the bootstrap toast element and is triggered by the stimulus controller.

I didn't use the stimulus notifications because bootstrap toasts disappear automatically without any additional JS.

https://github.com/rubyforgood/pet-rescue/assets/96994176/356da918-2da2-45de-abc5-350d66c42cd1


### Link to the issue

Fixes #186 