### PR TITLE
Invert association between Location and AdopterProfile

### DIFF
--- a/app/controllers/adopter_profiles_controller.rb
+++ b/app/controllers/adopter_profiles_controller.rb
@@ -4,8 +4,8 @@ class AdopterProfilesController < ApplicationController
   before_action :check_if_adopter, only: [:new, :create, :update, :show]
 
   # only allow new profile if one does not exist
-  # has_one for location provides new method build_location
-  # https://guides.rubyonrails.org/association_basics.html#has-one-association-reference
+  # belongs_to for location provides new method build_location
+  # https://guides.rubyonrails.org/association_basics.html#the-belongs-to-association
   def new
     if profile_nil?
       @adopter_profile = AdopterProfile.new

--- a/app/models/adopter_profile.rb
+++ b/app/models/adopter_profile.rb
@@ -38,18 +38,21 @@
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  adopter_account_id :bigint           not null
+#  location_id        :bigint           not null
 #
 # Indexes
 #
 #  index_adopter_profiles_on_adopter_account_id  (adopter_account_id)
+#  index_adopter_profiles_on_location_id         (location_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (adopter_account_id => adopter_accounts.id)
+#  fk_rails_...  (location_id => locations.id)
 #
 class AdopterProfile < ApplicationRecord
+  belongs_to :location, dependent: :destroy
   belongs_to :adopter_account
-  has_one :location, dependent: :destroy
   accepts_nested_attributes_for :location
   validates_associated :location
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -2,26 +2,17 @@
 #
 # Table name: locations
 #
-#  id                 :bigint           not null, primary key
-#  city_town          :string
-#  country            :string
-#  latitude           :float
-#  longitude          :float
-#  province_state     :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  adopter_profile_id :bigint           not null
-#
-# Indexes
-#
-#  index_locations_on_adopter_profile_id  (adopter_profile_id) UNIQUE
-#
-# Foreign Keys
-#
-#  fk_rails_...  (adopter_profile_id => adopter_profiles.id)
+#  id             :bigint           not null, primary key
+#  city_town      :string
+#  country        :string
+#  latitude       :float
+#  longitude      :float
+#  province_state :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #
 class Location < ApplicationRecord
-  belongs_to :adopter_profile
+  has_one :adopter_profile
   geocoded_by :address
   after_validation :geocode
 

--- a/db/migrate/20231002150909_change_association_between_location_and_adopter_profile.rb
+++ b/db/migrate/20231002150909_change_association_between_location_and_adopter_profile.rb
@@ -1,0 +1,35 @@
+class ChangeAssociationBetweenLocationAndAdopterProfile < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_reference :adopter_profiles, :location, foreign_key: true, index: {algorithm: :concurrently}
+
+      execute <<-SQL
+        UPDATE adopter_profiles
+        SET location_id = locations.id
+        FROM locations
+        WHERE locations.adopter_profile_id = adopter_profiles.id
+      SQL
+
+      remove_reference :locations, :adopter_profile
+      change_column_null :adopter_profiles, :location_id, false
+    end
+  end
+
+  def down
+    safety_assured do
+      add_reference :locations, :adopter_profile, foreign_key: true, index: {algorithm: :concurrently}
+
+      execute <<-SQL
+        UPDATE locations
+        SET adopter_profile_id = adopter_profiles.id
+        FROM adopter_profiles
+        WHERE locations.id = adopter_profiles.location_id
+      SQL
+
+      remove_reference :adopter_profiles, :location
+      change_column_null :locations, :adopter_profile_id, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_25_130443) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_02_150909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,7 +97,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_130443) do
     t.boolean "visit_laventana"
     t.text "visit_dates"
     t.text "referral_source"
+    t.bigint "location_id", null: false
     t.index ["adopter_account_id"], name: "index_adopter_profiles_on_adopter_account_id"
+    t.index ["location_id"], name: "index_adopter_profiles_on_location_id"
   end
 
   create_table "checklist_assignments", force: :cascade do |t|
@@ -136,7 +138,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_130443) do
   end
 
   create_table "locations", force: :cascade do |t|
-    t.bigint "adopter_profile_id", null: false
     t.string "country"
     t.string "city_town"
     t.string "province_state"
@@ -144,7 +145,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_130443) do
     t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["adopter_profile_id"], name: "index_locations_on_adopter_profile_id", unique: true
   end
 
   create_table "matches", force: :cascade do |t|
@@ -236,10 +236,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_25_130443) do
   add_foreign_key "adopter_applications", "adopter_accounts"
   add_foreign_key "adopter_applications", "pets"
   add_foreign_key "adopter_profiles", "adopter_accounts"
+  add_foreign_key "adopter_profiles", "locations"
   add_foreign_key "checklist_assignments", "checklist_template_items"
   add_foreign_key "checklist_assignments", "matches"
   add_foreign_key "checklist_template_items", "checklist_templates"
-  add_foreign_key "locations", "adopter_profiles"
   add_foreign_key "matches", "adopter_accounts"
   add_foreign_key "matches", "pets"
   add_foreign_key "pets", "organizations"

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -72,7 +72,14 @@ ActsAsTenant.with_tenant(organization) do
 
   @adopter_account_three = AdopterAccount.create!(user_id: @user_adopter_three.id)
 
+  @location_one = Location.create!(
+    country: "Canada",
+    province_state: "Alberta",
+    city_town: "Canmore"
+  )
+
   @adopter_profile_one = AdopterProfile.create!(
+    location_id: @location_one.id,
     adopter_account_id: @adopter_account_one.id,
     phone_number: "250 548 7721",
     contact_method: "phone",
@@ -108,14 +115,14 @@ ActsAsTenant.with_tenant(organization) do
     referral_source: "my friends friend"
   )
 
-  Location.create!(
-    adopter_profile_id: @adopter_profile_one.id,
-    country: "Canada",
-    province_state: "Alberta",
-    city_town: "Canmore"
+  @location_two = Location.create!(
+    country: "USA",
+    province_state: "Nevada",
+    city_town: "Reno"
   )
 
   @adopter_profile_two = AdopterProfile.create!(
+    location_id: @location_two.id,
     adopter_account_id: @adopter_account_two.id,
     phone_number: "250 548 7721",
     contact_method: "phone",
@@ -154,14 +161,14 @@ ActsAsTenant.with_tenant(organization) do
     referral_source: "my friends friend"
   )
 
-  Location.create!(
-    adopter_profile_id: @adopter_profile_two.id,
-    country: "USA",
-    province_state: "Nevada",
-    city_town: "Reno"
+  @location_three = Location.create!(
+    country: "Nonsense",
+    province_state: "Nonsense",
+    city_town: "Nonsense"
   )
 
   @adopter_profile_three = AdopterProfile.create!(
+    location_id: @location_three.id,
     adopter_account_id: @adopter_account_three.id,
     phone_number: "250 548 7721",
     contact_method: "phone",
@@ -198,13 +205,6 @@ ActsAsTenant.with_tenant(organization) do
     visit_laventana: true,
     visit_dates: "April 2 to May 7 2023",
     referral_source: "my friends friend"
-  )
-
-  Location.create!(
-    adopter_profile_id: @adopter_profile_three.id,
-    country: "Nonsense",
-    province_state: "Nonsense",
-    city_town: "Nonsense"
   )
 
   path = Rails.root.join("app", "assets", "images", "hero.jpg")

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -71,7 +71,14 @@ ActsAsTenant.with_tenant(organization) do
 
   @adopter_account_three = AdopterAccount.create!(user_id: @user_adopter_three.id)
 
+  @location_one = Location.create!(
+    country: "Canada",
+    province_state: "Alberta",
+    city_town: "Canmore"
+  )
+
   @adopter_profile_one = AdopterProfile.create!(
+    location_id: @location_one.id,
     adopter_account_id: @adopter_account_one.id,
     phone_number: "250 548 7721",
     contact_method: "phone",
@@ -107,14 +114,14 @@ ActsAsTenant.with_tenant(organization) do
     referral_source: "my friends friend"
   )
 
-  Location.create!(
-    adopter_profile_id: @adopter_profile_one.id,
-    country: "Canada",
-    province_state: "Alberta",
-    city_town: "Canmore"
+  @location_two = Location.create!(
+    country: "USA",
+    province_state: "Nevada",
+    city_town: "Reno"
   )
 
   @adopter_profile_two = AdopterProfile.create!(
+    location_id: @location_two.id,
     adopter_account_id: @adopter_account_two.id,
     phone_number: "250 548 7721",
     contact_method: "phone",
@@ -153,14 +160,14 @@ ActsAsTenant.with_tenant(organization) do
     referral_source: "my friends friend"
   )
 
-  Location.create!(
-    adopter_profile_id: @adopter_profile_two.id,
-    country: "USA",
-    province_state: "Nevada",
-    city_town: "Reno"
+  @location_three = Location.create!(
+    country: "Nonsense",
+    province_state: "Nonsense",
+    city_town: "Nonsense"
   )
 
   @adopter_profile_three = AdopterProfile.create!(
+    location_id: @location_three.id,
     adopter_account_id: @adopter_account_three.id,
     phone_number: "250 548 7721",
     contact_method: "phone",
@@ -197,13 +204,6 @@ ActsAsTenant.with_tenant(organization) do
     visit_laventana: true,
     visit_dates: "April 2 to May 7 2023",
     referral_source: "my friends friend"
-  )
-
-  Location.create!(
-    adopter_profile_id: @adopter_profile_three.id,
-    country: "Nonsense",
-    province_state: "Nonsense",
-    city_town: "Nonsense"
   )
 
   path = Rails.root.join("app", "assets", "images", "hero.jpg")

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     trait :with_adopter_profile do
       after :create do |account|
-        create(:adopter_profile, :with_location, adopter_account: account)
+        create(:adopter_profile, adopter_account: account)
       end
     end
   end
@@ -53,12 +53,7 @@ FactoryBot.define do
     referral_source { "friends" }
 
     adopter_account
-
-    trait :with_location do
-      after :create do |profile|
-        create :location, adopter_profile: profile
-      end
-    end
+    location
   end
 
   factory :checklist_assignment do
@@ -84,7 +79,11 @@ FactoryBot.define do
     sequence(:country) { |n| "Country#{n}" }
     province_state { Faker::Address.state }
 
-    adopter_profile
+    trait :with_adopter_profile do
+      after :create do |location|
+        create(:adopter_profile, location: location)
+      end
+    end
   end
 
   factory :organization do
@@ -166,7 +165,7 @@ FactoryBot.define do
       adopter_account
 
       after :create do |user|
-        create :adopter_profile, :with_location, adopter_account: user.adopter_account
+        create :adopter_profile, adopter_account: user.adopter_account
       end
     end
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class LocationTest < ActiveSupport::TestCase
   context "associations" do
-    should belong_to(:adopter_profile)
+    should have_one(:adopter_profile)
   end
 
   context "validations" do


### PR DESCRIPTION
# 🔗 Issue
Fixes #216 

# ✍️ Description
This PR inverts the association between `Location` and `AdopterProfile` models.
Now:
* `AdopterProfile` belongs to `Location`
*  `Location` has one `AdopterProfile`. 

@kasugaijin suggested in the issue that `Location` should use `has_many :adopter_profiles` relation but from my understanding of the codebase the `has_one` relation makes more sense. Please let me know if I'm wrong, I will change it if needed.


