### PR TITLE
Fix flash messages on the dashboard

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -3,6 +3,7 @@
 <%= render "layouts/shared/head" %>
 
   <body>
+    <%= render "layouts/shared/flash_messages" %>
     <div id="db-wrapper">
       <%= render "layouts/dashboard/sidebar" %>
 
@@ -267,12 +268,12 @@
                                           fragment_class: "breadcrumb-item" %>
                         </div>
                         <div class="d-flex">
-                          <%= yield :button %>  
+                          <%= yield :button %>
                         </div>
                     </div>
                 </div>
-                
-                
+
+
                 <%= yield %>
                 </div>
             </section>


### PR DESCRIPTION
# 🔗 Issue
Fixes #235 

# ✍️ Description
I think flash messages were removed from the dashboard by mistake. This brings them back. 

# 📷 Screenshots/Demos

https://github.com/rubyforgood/pet-rescue/assets/96994176/c188fdf4-3059-4d96-b04b-26cf43136c91