### PR TITLE
Increase process timeout in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ end
 gem "chartkick", "~> 5.0"
 
 # Adds location data for cities and states around the world
-gem "city-state", "~> 0.1.0"
+gem "city-state", "~> 1.1.0"
 
 # Adds a simple way to fetch with Javascript
 gem "requestjs-rails", "~> 0.0.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,8 +117,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chartkick (5.0.3)
-    city-state (0.1.0)
-      rubyzip (>= 1.1)
+    city-state (1.1.0)
+      rubyzip (>= 2.3)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -193,6 +193,7 @@ GEM
     geocoder (1.8.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.23.4)
     google-protobuf (3.23.4-arm64-darwin)
     google-protobuf (3.23.4-x86_64-darwin)
     google-protobuf (3.23.4-x86_64-linux)
@@ -249,6 +250,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.4)
     minitest (5.19.0)
     mocha (2.1.0)
       ruby2_keywords (>= 0.0.5)
@@ -268,6 +270,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.3-x86_64-darwin)
@@ -362,6 +367,9 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    sass-embedded (1.64.1)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     sass-embedded (1.64.1-arm64-darwin)
       google-protobuf (~> 3.23)
     sass-embedded (1.64.1-x86_64-darwin)
@@ -443,6 +451,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   arm64-darwin-23
+  ruby
   x86_64-darwin-22
   x86_64-linux
 
@@ -458,7 +467,7 @@ DEPENDENCIES
   brakeman
   capybara
   chartkick (~> 5.0)
-  city-state (~> 0.1.0)
+  city-state (~> 1.1.0)
   cuprite
   dartsass-rails
   debug

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,9 +5,7 @@ require "capybara/cuprite"
 
 require "evil_systems"
 
-EvilSystems.initial_setup
-# To pass in driver_options to cuprite you can do the following:
-# EvilSystems.initial_setup(driver_options: { process_timeout: 20 })
+EvilSystems.initial_setup(driver_options: {process_timeout: 20})
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :evil_cuprite


### PR DESCRIPTION
# 🔗 Issue
Fixes #203 

# ✍️ Description
* Increased `process_timeout` for the driver to 20s (maybe 10s would work just fine but 20s is safer and doesn't cost us anything)
* I also bumped `city-state` gem to a newer version because it was throwing deprecation warnings all the time
