### PR TITLE
Add All Contributors to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,14 @@ These are just some of the documents put together before writing any code:
 * Figma site design: [here](https://www.figma.com/file/x3iM31l8csY7mT0VwKykhT/BPR---Wireframes---Ami?node-id=530186%3A154&t=mgRlseVd2LTKPX4o-1)
 * Model association diagram: [here](https://lucid.app/lucidchart/a915c03c-3c09-454d-837b-f3d2768f5722/edit?viewport_loc=-25%2C-973%2C3565%2C2341%2C0_0&invitationId=inv_85cf2967-7b33-4030-903f-9655e767cbbf)
 
+
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/app/.all-contributorsrc
+++ b/app/.all-contributorsrc
@@ -1,0 +1,4 @@
+{
+  "projectName": "Pet Rescue",
+  "projectOwner": "Ruby for Good"
+}


### PR DESCRIPTION
# 🔗 Issue
[232](https://github.com/rubyforgood/pet-rescue/issues/232)

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
The AllContributors intstall instructions here: https://allcontributors.org/docs/en/bot/installation 
Step 1: I do not think I am authorized to do so. I can select the Pet Rescue repo to add access for AllContributors, but it says 'Request' so I think someone may have to approve (one of my multiple requests).
Step 2: I do not have the ability to modify these configurations on the repo - someone else might have to do that. 
Step 3: I added the necessary to readme.md and created the required file.

Hopefully someone can advise/authorise what needs to be done to install the bot on the repo.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
