### PR TITLE
Apply bootstrap_form to newly added organization_profile form

### DIFF
--- a/app/views/organizations/organization_profiles/_form.html.erb
+++ b/app/views/organizations/organization_profiles/_form.html.erb
@@ -1,10 +1,7 @@
-<%= form_with model: profile, :url => organization_profile_path do |form| %>
-
+<%= bootstrap_form_with model: profile, :url => organization_profile_path do |form| %>
   <% if profile.errors.count > 0 %>
     <div class="alert alert-danger mt-1" role="alert">
-      <p>
-        <%= t '.please_fix_the_errors' %>
-      </p>
+      <%= t '.please_fix_the_errors' %>
     </div>
   <% end %>
 
@@ -13,30 +10,19 @@
     <h3>Contact</h3>
 
     <div class="form-group">
-      <%= form.label :phone_number, class: 'bigger' %>
       <%= form.telephone_field :phone_number,
                               autofocus: true,
                               placeholder: "10 digit number",
                               class: 'form-control' %>
-
-      <% profile.errors.full_messages_for(:phone_number).each do |message| %>
-        <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-      <% end %>
     </div>
     
     <div class="form-group">
-      <%= form.label :email %>
       <%= form.text_field :email, placeholder: "john@email.com", class: 'form-control' %>
-
-      <% profile.errors.full_messages_for(:email).each do |message| %>
-        <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-      <% end %>
     </div>
 
     <%# nested form for locations table %>
     <div class="form-group bigger" data-controller="country-state">
       <%= form.fields_for :location do |location| %>
-          <%= location.label :country %>
           <%= location.select :country,
                               CS.countries.invert,
                               { prompt: "Please select" },
@@ -50,7 +36,6 @@
             <div class="alert alert-danger mt-1" role="alert"><%= error.message %></div>
           <% end %>
 
-          <%= location.label :province_state, 'Province/State' %>
           <%= location.select :province_state,
                               CS.states(location.object.country).invert,
                               { prompt: "Please select" },
@@ -61,7 +46,6 @@
             <div class="alert alert-danger mt-1" role="alert"><%= error.message %></div>
           <% end %>
 
-          <%= location.label :city_town, 'City/Town' %>
           <%= location.text_field :city_town, class: 'form-control' %>
           <% profile.location.custom_messages(:city_town).each do |error| %>
             <div class="alert alert-danger mt-1" role="alert"><%= error.message %></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,16 @@ en:
     submit: "Submit"
     status: "Status"
     back: "Back"
+  activerecord:
+    models:
+      location: Location
+    attributes:
+      location:
+        country: Country
+        province_state: Province/State
+        city_town: City/Town
+        latitude: Latitude
+        longitude: Longitude
   errors:
     attributes:
       general:


### PR DESCRIPTION
# 🔗 Issue
[213](https://github.com/rubyforgood/pet-rescue/issues/213)

# ✍️ Description
We added a new gem `bootstrap_form` which makes forms better readable, reducing the need for label and error specific fields. 

As this form was introduced after the gem has been introduced, this was still using the old pattern. This changes with this pr :)

# 📷 Screenshots/Demos
Before: 
![image](https://github.com/rubyforgood/pet-rescue/assets/20230045/14916f19-9e83-49bd-ba53-bc133332da78)
Errors:
![image](https://github.com/rubyforgood/pet-rescue/assets/20230045/7b51b41d-aef3-4feb-8fd5-b536906ef172)

After (Already upgraded with new locale keys): 
![image](https://github.com/rubyforgood/pet-rescue/assets/20230045/d30fd309-54eb-4805-ba7f-aa96bdd1b4d2)


Errors:
![image](https://github.com/rubyforgood/pet-rescue/assets/20230045/bd007186-e254-48ff-903d-a0633c8a0214)



