### PR TITLE
Fix pets form field hints, asterisk, validations

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -34,9 +34,9 @@
             <% end %>
 
             <div class="form-group mb-3">
-              <i>(leave blank if you don't want to change it)</i><br />
               <%= f.password_field :password, autocomplete: "new-password", 
                                     class: 'form-control', label: 'New password' %>
+              <i>(leave blank if you don't want to change it)</i><br />
               <% if @minimum_password_length %>
                 <em><%= @minimum_password_length %> characters minimum</em>
               <% end %>
@@ -58,11 +58,11 @@
             </div>
 
             <div class="form-group mb-3">
-                          <i>(we need your current password to confirm your changes)</i><br />
               <%= f.password_field :current_password, 
                                   autocomplete: "current-password",
                                   required: true,
                                   class: 'form-control' %>
+              <i>(we need your current password to confirm your changes)</i><br />
             </div>
 
             <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -34,13 +34,13 @@
           </div>
 
           <div class="form-group mb-3 bigger">
-            <% if @minimum_password_length %>
-              <em>(<%= @minimum_password_length %> characters minimum)</em>
-            <% end %><br />
             <%= f.password_field :password,
                                  required: true,
                                  autocomplete: "new-password",
                                  class: 'form-control' %>
+            <% if @minimum_password_length %>
+              <em>(<%= @minimum_password_length %> characters minimum)</em>
+            <% end %><br />
           </div>
 
           <div class="form-group mb-3 bigger">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -45,7 +45,7 @@
 
           <div class="form-group mb-3 bigger">
             <%= f.check_box :tos_agreement, required: true,
-                            class: 'me-2', label: '*I agree to the' %>
+                            class: 'me-2', label: 'I agree to the' %>
             <%= link_to 'Terms and Conditions', terms_and_conditions_path,
                         target: '_blank', class: 'text-decoration-none' %>
             <span>& </span>

--- a/app/views/organizations/pets/_form.html.erb
+++ b/app/views/organizations/pets/_form.html.erb
@@ -7,10 +7,6 @@
 
       <div class='form-group'>
         <%= form.text_field :name, class: 'form-control' %>
-
-        <% pet.errors.full_messages_for(:name).each do |message| %>
-          <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-        <% end %>
       </div>
 
       <div class='form-group d-flex'>
@@ -32,37 +28,19 @@
                         [[t('general.male'), 'male'], [t('general.female'), 'female']],
                         { prompt: t('general.please_select') },
                         class: 'form-control' %>
-
-        <% pet.errors.full_messages_for(:sex).each do |message| %>
-          <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-        <% end %>
       </div>
 
       <div class='form-group'>
         <%= form.text_field :breed, class: 'form-control' %>
-
-        <% pet.errors.full_messages_for(:breed).each do |message| %>
-          <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-        <% end %>
       </div>
 
       <div class="form-group mt-3">
         <div class='form-group d-flex'>
           <div class='me-3'>
             <%= form.text_field :weight_from, class: 'form-control', label: 'From weight'  %>
-            <% if pet.errors[:weight_from].any? %>
-              <div class="alert alert-danger mt-1" role="alert">
-                <%= pet.errors.full_messages_for(:weight_from).first %>
-              </div>
-            <% end %>
           </div>
           <div class='me-3'>
             <%= form.text_field :weight_to, class: 'form-control', label: 'To weight' %>
-            <% if pet.errors[:weight_to].any? %>
-              <div class="alert alert-danger mt-1" role="alert">
-                <%= pet.errors.full_messages_for(:weight_to).first %>
-              </div>
-            <% end %>
           </div>
           <div>
             <%= form.select :weight_unit,
@@ -84,10 +62,6 @@
                              class: 'form-control' %>
           <div data-counter-target='output' class='small mt-2 d-flex flex-row-reverse'></div>
         </div>
-
-        <% pet.errors.full_messages_for(:description).each do |message| %>
-          <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-        <% end %>
       </div>
 
       <div class='form-group'>


### PR DESCRIPTION
# 🔗 Issue
[#244](https://github.com/rubyforgood/pet-rescue/issues/244)

# ✍️ Description
I moved the field hints below inputs for an improved appearance and removed the extra asterisk that remained in sign up page. I also removed the old validation errors in favor of the bootstrap_form validation errors, however it dawned on me that the other forms all still have hardcoded validation error messages. I'm not sure if that warrants a new issue, or how we wanted to handle that. 

For the record, if we want to continue to write our own custom validation error messages, bootstrap_form offers [options for handling validations and errors](https://github.com/bootstrap-ruby/bootstrap_form#validation-and-errors) like disabling automatic inline errors. I just assumed we wanted to let bootstrap_form handle this as well, so please let me know if I'm wrong.

# 📷 Screenshots/Demos
With old error validations
![old_form_validations](https://github.com/rubyforgood/pet-rescue/assets/102765102/0ecb4b96-fc69-490d-ac66-17c34b41e241)
Removed old error validations leaving only bootstrap_form errors
![removed_old_form_validations](https://github.com/rubyforgood/pet-rescue/assets/102765102/74599563-95ce-4cef-8767-bd508b3837cf)

