### PR TITLE
Display invitation status on staff index

### DIFF
--- a/app/models/staff_account.rb
+++ b/app/models/staff_account.rb
@@ -27,4 +27,8 @@ class StaffAccount < ApplicationRecord
   def email
     user.email.to_s
   end
+
+  def status
+    user.invited_to_sign_up? ? :invitation_sent : :enabled
+  end
 end

--- a/app/views/organizations/staff/index.html.erb
+++ b/app/views/organizations/staff/index.html.erb
@@ -59,7 +59,7 @@
                     </div>
                     <div class="d-flex justify-content-between pt-2">
                       <span>Status</span>
-                      <span class="text-dark"> Enabled </span>
+                      <span class="text-dark"><%= t("staff_accounts.status.#{staff.status}") %></span>
                     </div>
                   </div>
                 </div>
@@ -110,7 +110,7 @@
                       <%= staff.created_at.strftime("%d %B, %Y") %>
                     </td>
                     <td>
-                      Enabled
+                      <%= t("staff_accounts.status.#{staff.status}") %>
                     </td>
 
                     <td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,9 +101,9 @@ en:
         transport before an adoption can be approved.</li>
       after_you_adopt: "After you apply to adopt"
       after_you_adopt_items_html: |
-        <li>Your application history will be shown on 'My Applications' page</li> 
-        <li>Application reviews generally take 4-6 days, depending on volume</li> 
-        <li>We will contact you for further discussion if you are shortlisted </li> 
+        <li>Your application history will be shown on 'My Applications' page</li>
+        <li>Application reviews generally take 4-6 days, depending on volume</li>
+        <li>We will contact you for further discussion if you are shortlisted </li>
         <li>We work hard to match pets and adopters, so please try again if you are not successful first time round </li>
       create_an_account: "Create an account to apply for this pet"
       status:
@@ -207,3 +207,7 @@ en:
       will_you_pick_up_the_pet: "Will you or a friend be in La Ventana in person to pick up the pet?"
       what_dates_will_you_be: "What dates will you be in La Ventana?"
       how_did_you_hear: "How did you find out about Baja Pet Rescue?"
+  staff_accounts:
+    status:
+      invitation_sent: "Invitation sent"
+      enabled: "Enabled"


### PR DESCRIPTION
# 🔗 Issue
Fixes #266 

# ✍️ Description
Now, the status column on the staff index displays "Invitation sent" if the invitation is sent but not accepted or "Enabled" if the invitation is accepted. 

# 📷 Screenshots/Demos

https://github.com/rubyforgood/pet-rescue/assets/96994176/18dab9c6-fcda-4c68-8e65-f167f4e10cc8


