### PR TITLE
281: Pets Show Overview Tab make Edit and Delete buttons more visible

### DIFF
--- a/app/views/organizations/pets/show.html.erb
+++ b/app/views/organizations/pets/show.html.erb
@@ -35,24 +35,7 @@
                 <div>
                   <h4 class="mb-0">Summary</h4>
                 </div>
-                <!-- dropdown  -->
-                <div>
-                        <span class="dropdown dropstart">
-                          <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" id="DropdownTen" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <i class="fe fe-more-vertical"></i>
-                          </a>
-                          <span class="dropdown-menu" aria-labelledby="DropdownTen">
-                            <span class="dropdown-header">Settings</span>
-                            <%= link_to t('general.edit'), edit_pet_path(@pet), class: 'dropdown-item' %>
-                            <%= link_to t('general.delete'), pet_path(@pet), class: 'dropdown-item',
-                                        data:
-                                          {
-                                            turbo_method: :delete,
-                                            turbo_confirm: t('organization_pets.show.are_you_sure_delete')
-                                          } %>
-                          </span>
-                        </span>
-                </div>
+                <%= link_to t('general.edit'), edit_pet_path(@pet), class: 'btn btn-outline-dark' %>
               </div>
 
 
@@ -133,6 +116,12 @@
               </ul>
             </div>
           </div>
+          <%= link_to t('general.delete'), pet_path(@pet), class: 'btn btn-outline-dark mt-2',
+                                      data:
+                                        {
+                                          turbo_method: :delete,
+                                          turbo_confirm: t('organization_pets.show.are_you_sure_delete')
+                                        } %>
         </div>
       </div>
 

--- a/app/views/organizations/pets/show.html.erb
+++ b/app/views/organizations/pets/show.html.erb
@@ -116,7 +116,7 @@
               </ul>
             </div>
           </div>
-          <%= link_to t('general.delete'), pet_path(@pet), class: 'btn btn-outline-dark mt-2',
+          <%= link_to t('general.delete'), pet_path(@pet), class: 'btn btn-outline-danger mt-2',
                                       data:
                                         {
                                           turbo_method: :delete,


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

[#281](https://github.com/rubyforgood/pet-rescue/issues/281)

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Replaced the dropdown button and drop down with an edit button and added a delete button beneath the summary card. I matched the new buttons to the other button the page. If you'd prefer other styling, I can change it. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
<img width="1332" alt="Screenshot 2023-10-18 at 12 36 09 PM" src="https://github.com/rubyforgood/pet-rescue/assets/82609260/3aa9d08b-e9ae-4721-ab98-7b0b781e012a">



