### PR TITLE
Fix flaky tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,7 @@ class ActiveSupport::TestCase
 
   def teardown
     ActsAsTenant.current_tenant = nil
+    Rails.application.routes.default_url_options[:script_name] = ""
   end
 
   def check_messages


### PR DESCRIPTION
# ✍️ Description
Once `default_url_options[:script_name]` was set (e.g. by calling `set_organization` [here](https://github.com/rubyforgood/pet-rescue/blob/main/test/integration/adoptable_pets_index_test.rb#L7)) it was then leaking to other tests. This change ensures that the script_name is cleared after each test so it should fix the majority of flaky tests.