### PR TITLE
Add Applications list to Pet show

### DIFF
--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -1,46 +1,44 @@
-<nav class="navbar navbar-vertical h-auto align-items-baseline">
-  <div class="vh-100 col-lg-3 col-sm-3 position-fixed" data-simplebar>
-    <!-- Brand logo -->
-    <a class="navbar-brand">
-      <img src="" alt="">
-    </a>
+<nav class="navbar navbar-vertical fixed-top vh-100 col-lg-3 col-sm-3" data-simplebar>
+  <!-- Brand logo -->
+  <a class="navbar-brand">
+    <img src="" alt="">
+  </a>
 
-    <!-- Navbar nav -->
-    <ul class="navbar-nav flex-column" id="sideNavbar">
+  <!-- Navbar nav -->
+  <ul class="navbar-nav flex-column" id="sideNavbar">
+    <li class="nav-item">
+      <div class="navbar-heading">Menu</div>
+    </li>
+    <% if current_user.staff_account && current_user.staff_account.has_role?(:admin, current_user.staff_account.organization) %>
       <li class="nav-item">
-        <div class="navbar-heading">Menu</div>
+        <%= active_link_to settings_path, class: "nav-link" do %>
+          <i class="nav-icon fe fe-book me-2"></i> Settings
+        <% end %>
       </li>
-      <% if current_user.staff_account && current_user.staff_account.has_role?(:admin, current_user.staff_account.organization) %>
-        <li class="nav-item">
-          <%= active_link_to settings_path, class: "nav-link" do %>
-            <i class="nav-icon fe fe-book me-2"></i> Settings
-          <% end %>
-        </li>
-        <li class="nav-item">
-          <%= active_link_to staff_index_path, class: "nav-link" do %>
-            <i class="nav-icon fe fe-book me-2"></i> Staff
-          <% end %>
-        </li>
+      <li class="nav-item">
+        <%= active_link_to staff_index_path, class: "nav-link" do %>
+          <i class="nav-icon fe fe-book me-2"></i> Staff
+        <% end %>
+      </li>
+    <% end %>
+    <li class="nav-item">
+      <%= active_link_to adoption_application_reviews_path, class: "nav-link" do %>
+        <i class="nav-icon fe fe-book me-2"></i> Adoption Applications
       <% end %>
-      <li class="nav-item">
-        <%= active_link_to adoption_application_reviews_path, class: "nav-link" do %>
-          <i class="nav-icon fe fe-book me-2"></i> Adoption Applications
-        <% end %>
-      </li>
-      <li class="nav-item">
-        <%= active_link_to foster_application_reviews_path, class: "nav-link" do %>
-          <i class="nav-icon fe fe-book me-2"></i> Foster Applications
-        <% end %>
-      </li>
-      <li class="nav-item">
-        <%= active_link_to pets_path, class: "nav-link" do %>
-          <i class="nav-icon fe fe-book me-2"></i> Pets
-        <% end %>
-      </li>
-      <!-- Nav item -->
-      <li class="nav-item">
-        <div class="nav-divider"></div>
-      </li>
-    </ul>
-  </div>
+    </li>
+    <li class="nav-item">
+      <%= active_link_to foster_application_reviews_path, class: "nav-link" do %>
+        <i class="nav-icon fe fe-book me-2"></i> Foster Applications
+      <% end %>
+    </li>
+    <li class="nav-item">
+      <%= active_link_to pets_path, class: "nav-link" do %>
+        <i class="nav-icon fe fe-book me-2"></i> Pets
+      <% end %>
+    </li>
+    <!-- Nav item -->
+    <li class="nav-item">
+      <div class="nav-divider"></div>
+    </li>
+  </ul>
 </nav>

--- a/app/views/nice_partials/_applications.html.erb
+++ b/app/views/nice_partials/_applications.html.erb
@@ -5,27 +5,54 @@
         <div class="card-header">
           <div class="d-flex justify-content-between align-items-center">
             <div>
-              <h4 class="mb-0">Summary</h4>
-            </div>
-            <!-- dropdown  -->
-            <div>
-              <span class="dropdown dropstart">
-                <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" id="DropdownTen" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  <i class="fe fe-more-vertical"></i>
-                </a>
-                <span class="dropdown-menu" aria-labelledby="DropdownTen">
-                  <span class="dropdown-header">Settings</span>
-                  <%= link_to t('general.edit'), edit_pet_path(@pet), class: 'dropdown-item' %>
-                  <%= link_to t('general.delete'), pet_path(@pet), class: 'dropdown-item',
-                    data:
-                      {
-                        turbo_method: :delete,
-                        turbo_confirm: t('organization_pets.show.are_you_sure_delete')
-                      } %>
-                </span>
-              </span>
+              <h4 class="mb-0">Applications</h4>
             </div>
           </div>
+        </div>
+        <div class="card-body">
+          <div class='p-2'>
+            <% @pet.adopter_applications.each do |app| %>
+              <div class="row mb-3 rounded py-2 application-info
+                <%= 'awaiting-review' if app.status == 'awaiting_review' %>
+                <%= 'withdrawn' if app.status == 'withdrawn' %>
+                <%= 'under-review' if app.status == 'under_review' %>
+                <%= 'adoption-pending' if app.status == 'adoption_pending' %>
+                <%= 'successful-applicant' if app.status == 'successful_applicant' %>">
+                <!--adopter name-->
+                <div class="col-md-3 d-flex align-items-center">
+                  <p class='bigger'>
+                    <%= app.adopter_account.user.first_name%> <%= app.adopter_account.user.last_name%>
+                  </p>
+                </div>
+
+                <!--application status-->
+                <div class="col-md-3 d-flex align-items-center bigger">
+                  <div class="<%= 'fw-bold' if app.status == 'withdrawn' %>">
+                    Status: <%= app.status.titleize%>
+                  </div>
+                </div>
+
+                <% unless app.status == 'successful_applicant' %>
+                  <!--adopter profile link-->
+                  <div class="col-md-3 d-md-flex align-items-center justify-content-center bigger">
+                    <%= link_to 'Adopter Profile', profile_review_path(app.adopter_account.adopter_profile.id), target: "_blank" %>
+                  </div>
+                <% end %>
+
+                <!--edit application button-->
+                <div class="col-md-3 d-flex align-items-center justify-content-md-center">
+                  <%= link_to 'Edit Application', edit_adoption_application_review_path(app.id), class: 'btn btn-outline-dark mt-3 mt-md-0 mb-3 mb-md-0' %>
+                </div>
+
+                <% if app.status == 'successful_applicant' %>
+                <!--create adoption button-->
+                  <div class="col-md-3 d-flex align-items-center justify-content-md-center">
+                    <%= link_to 'Create Adoption', create_adoption_path(pet_id: pet.id, adopter_account_id: app.adopter_account.id), data: { turbo_method: :post, turbo_confirm: "Click OK to finalize this adoption." }, class: 'custom-btn-pink mb-3 mb-md-0 pt-2 pb-2 ps-4 pe-4' %>
+                  </div>
+                <% end %>
+              </div> <!--row-->
+            <% end %>
+          </div> <!--card-->
         </div>
       </div>
     </div>

--- a/app/views/organizations/adoption_application_reviews/_search_results.html.erb
+++ b/app/views/organizations/adoption_application_reviews/_search_results.html.erb
@@ -16,18 +16,18 @@
             <%= 'withdrawn' if app.status == 'withdrawn' %>
             <%= 'under-review' if app.status == 'under_review' %>
             <%= 'adoption-pending' if app.status == 'adoption_pending' %>
-            <%= 'successful-applicant' if app.status == 'successful_applicant' %>">    
+            <%= 'successful-applicant' if app.status == 'successful_applicant' %>">
 
             <!--pet name-->
             <div class="col-md-3 d-flex align-items-center">
               <p class='bigger'>
-                Applicant: Fix me.
+                Applicant: <%= app.adopter_account.user.first_name%> <%= app.adopter_account.user.last_name%>
               </p>
             </div>
 
             <!--application status-->
             <div class="col-md-3 d-flex align-items-center bigger">
-              <div class="<%= 'fw-bold' if app.status == 'withdrawn' %>"> 
+              <div class="<%= 'fw-bold' if app.status == 'withdrawn' %>">
                 Status: <%= app.status.titleize%>
               </div>
             </div>
@@ -49,12 +49,12 @@
               <% if app.status == 'successful_applicant' %>
                 <!--create adoption button-->
                 <div class="col-md-3 d-flex align-items-center justify-content-md-center">
-                  <%= link_to 'Create Adoption', 
-                              create_adoption_path(pet_id: pet.id, 
+                  <%= link_to 'Create Adoption',
+                              create_adoption_path(pet_id: pet.id,
                                                   adopter_account_id: app.adopter_account.id),
-                              data: { turbo_method: :post, 
+                              data: { turbo_method: :post,
                                       turbo_confirm: "Click OK to finalize this adoption." },
-                              class: 'custom-btn-pink mb-3 mb-md-0 
+                              class: 'custom-btn-pink mb-3 mb-md-0
                                       pt-2 pb-2 ps-4 pe-4' %>
                 </div>
               <% end %>

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -31,12 +31,12 @@
             <%= f.submit t('general.submit'), class: 'btn btn-outline-dark' %>
           </div>
         <% end %>
-        
+
         <!--form2-->
         <%# only show pet name seletion if collection is greater than e.g., 5 pets? %>
         <%= bootstrap_form_with url: '/pets', class: 'mb-3 mb-md-0', method: :get do | f | %>
           <div class="d-flex gap-3 form-group">
-            <%= f.collection_select :pet_id, @collection, :id, :name, 
+            <%= f.collection_select :pet_id, @collection, :id, :name,
                                     { prompt: t('.filter_by_name') },
                                     class: 'form-control' %>
             <%= f.submit t('general.submit'), class: 'btn btn-outline-dark' %>

--- a/test/integration/adoptable_pet_show_test.rb
+++ b/test/integration/adoptable_pet_show_test.rb
@@ -1,6 +1,15 @@
 require "test_helper"
 
 class AdoptablePetShowTest < ActionDispatch::IntegrationTest
+  setup do
+    ActsAsTenant.current_tenant = create(:organization, slug: "test")
+    @user = create(:user, :verified_staff)
+    @pet = create(:pet, organization: @user.staff_account.organization)
+    @adopter_account = create(:adopter_account, :with_adopter_profile)
+    @adopter_applications = create_list(:adopter_application, 3, pet: @pet, adopter_account: @adopter_account)
+    sign_in @user
+  end
+
   test "unauthenticated users see create account prompt and link" do
     skip("while new ui is implemented")
     # pet = create(:pet)
@@ -104,13 +113,7 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
   end
 
   test "staff can view list of applications when selecting the applications tab" do
-    # pet = create(:pet)
-    sign_in create(:user, :verified_staff)
-    adopter_applications = create(:adopter_application)
-    pet = adopter_applications.first.pet
-    debugger
-    get "/#{pet.organization.slug}/pets/#{pet.id}?active_tab=applications"
-
-    assert_select "div.row.mb-3.rounded.py-2.application-info", {count: adopter_applications.length}
+    get "/#{@pet.organization.slug}/pets/#{@pet.id}?active_tab=applications"
+    assert_select "div.row.mb-3.rounded.py-2.application-info", {count: @adopter_applications.length}
   end
 end

--- a/test/integration/adoptable_pet_show_test.rb
+++ b/test/integration/adoptable_pet_show_test.rb
@@ -102,4 +102,15 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
     # check_messages
     # assert_equal "You can only view pets that need adoption.", flash[:alert]
   end
+
+  test "staff can view list of applications when selecting the applications tab" do
+    # pet = create(:pet)
+    sign_in create(:user, :verified_staff)
+    adopter_applications = create(:adopter_application)
+    pet = adopter_applications.first.pet
+    debugger
+    get "/#{pet.organization.slug}/pets/#{pet.id}?active_tab=applications"
+
+    assert_select "div.row.mb-3.rounded.py-2.application-info", {count: adopter_applications.length}
+  end
 end


### PR DESCRIPTION
Co-authored-by: FionaDL fionadlapham@gmail.com

# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/258

# ✍️ Description
1. Added a partial that will render all applications on the pet show page when the tab applications is selected
2. Fixed sidebar styling as it was spilling into the contents of the web page and interfering with the tab navlinks
3. Fixed applicant name at `/adoption_application_reviews`
4. Adds tests for application tab

# 📷 Screenshots/Demos
<img width="959" alt="image" src="https://github.com/rubyforgood/pet-rescue/assets/30131907/510fa1b5-3ac2-4aa2-8f01-ddb3a1a62983">

