### PR TITLE
Remove image and file field from pet form

### DIFF
--- a/app/views/organizations/pets/_form.html.erb
+++ b/app/views/organizations/pets/_form.html.erb
@@ -11,7 +11,7 @@
 
       <div class='form-group d-flex'>
         <div class='me-3'>
-          <span class='form-control'>
+          <span class=''>
             <%= form.date_select :birth_date,
                                  start_year: Date.today.year - 20,
                                  end_year: Date.today.year %>
@@ -69,35 +69,6 @@
             <%= form.hidden_field :application_paused, value: false %>
             <%= form.check_box :application_paused, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" }, true, false %>
         </div>
-      </div>
-
-      <div class='form-group mt-3'>
-        <%= form.file_field :append_images, multiple: true,
-                            class: "custom-attachments",
-                            label: 'Attach images' %>
-
-        <% pet.errors.full_messages_for(:images).each do |message| %>
-          <div class="alert alert-danger mt-1" role="alert"><%= message %></div>
-        <% end %>
-      </div>
-
-      <div>
-        <% if pet.images.attached? %>
-          <p><%= t('.uploaded_images') %></p>
-          <div class='row row-cols-1 row-cols-lg-5 g-6'>
-            <% pet.images.each do |image| %>
-              <% if image.created_at %>
-                <div class='d-flex flex-column align-items-center'>
-                  <%= image_tag image, class: 'uploaded-image rounded mt-2 mb-2' %>
-                  <%= link_to t('general.delete'),
-                              purge_attachment_path(image),
-                              data: { turbo_method: "delete" },
-                              class: 'delete-button' %>
-                </div>
-              <% end %>
-            <% end %>
-          </div>
-        <% end %>
       </div>
 
       <%= form.submit t('general.save'), class: 'btn btn-outline-dark mb-3 mt-4' %>

--- a/app/views/organizations/pets/show.html.erb
+++ b/app/views/organizations/pets/show.html.erb
@@ -116,12 +116,12 @@
               </ul>
             </div>
           </div>
-          <%= link_to t('general.delete'), pet_path(@pet), class: 'btn btn-outline-danger mt-2',
-                                      data:
-                                        {
-                                          turbo_method: :delete,
-                                          turbo_confirm: t('organization_pets.show.are_you_sure_delete')
-                                        } %>
+          <%= 
+            button_to t('general.delete'), 
+            pet_path(@pet), method: :delete, 
+            class: 'btn btn-outline-danger mt-2', 
+            data: { turbo_confirm: t('.are_you_sure_delete') } 
+          %>
         </div>
       </div>
 


### PR DESCRIPTION
…ng these in the Files tab of Pet show page. Also convert link_to to button_to as the former was not working

# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/283

# ✍️ Description
Quick fix to remove image and upload from pets new and edit forms. File uploads will be handled in the Files tab of pets show.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

Cleaned up pet form 
![image](https://github.com/rubyforgood/pet-rescue/assets/95949082/4eaca5d3-7045-4cca-a323-e266fef68655)
