### PR TITLE
Activate and deactivate staff

### DIFF
--- a/app/controllers/organizations/staff_controller.rb
+++ b/app/controllers/organizations/staff_controller.rb
@@ -5,4 +5,20 @@ class Organizations::StaffController < Organizations::BaseController
   def index
     @staff_accounts = StaffAccount.all
   end
+
+  def deactivate
+    staff_account = StaffAccount.find(params[:staff_id])
+    if staff_account.user != current_user
+      staff_account.deactivate
+      redirect_to staff_index_path, notice: "Staff account deactivated."
+    else
+      redirect_to staff_index_path, alert: "You can't deactivate yourself."
+    end
+  end
+
+  def activate
+    staff_account = StaffAccount.where(organization: current_tenant).find(params[:staff_id])
+    staff_account.activate
+    redirect_to staff_index_path, notice: "Staff account activated."
+  end
 end

--- a/app/models/staff_account.rb
+++ b/app/models/staff_account.rb
@@ -29,6 +29,20 @@ class StaffAccount < ApplicationRecord
   end
 
   def status
-    user.invited_to_sign_up? ? :invitation_sent : :enabled
+    if user.invited_to_sign_up?
+      :invitation_sent
+    elsif deactivated_at
+      :deactivated
+    else
+      :enabled
+    end
+  end
+
+  def deactivate
+    update(deactivated_at: Time.now) unless deactivated_at
+  end
+
+  def activate
+    update(deactivated_at: nil) if deactivated_at
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,4 +69,12 @@ class User < ApplicationRecord
   def custom_messages(attribute)
     errors.where(attribute)
   end
+
+  def active_for_authentication?
+    super && !staff_account&.deactivated_at
+  end
+
+  def inactive_message
+    staff_account.deactivated_at ? :deactivated : super
+  end
 end

--- a/app/views/layouts/shared/_flash_messages.html.erb
+++ b/app/views/layouts/shared/_flash_messages.html.erb
@@ -1,6 +1,6 @@
 <div class="toast-container fixed-top top-0 start-50 translate-middle-x p-3">
   <% flash.each do |type, message| %>
-    <% flash_color = type == :alert ? 'danger' : 'primary' %>
+    <% flash_color = type.to_s == "alert" ? 'danger' : 'primary' %>
     <div data-controller="flash-message" class="toast align-items-center text-white bg-<%= flash_color %> border-0" role="status" aria-live="polite" aria-atomic="true">
       <div class="d-flex">
         <div class="toast-body">

--- a/app/views/organizations/staff/index.html.erb
+++ b/app/views/organizations/staff/index.html.erb
@@ -118,15 +118,23 @@
                         <a href="#" class="fe fe-mail text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Message" data-bs-original-title="Message"></a>
                         <a href="#" class="text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Delete" data-bs-original-title="Delete"><i class="fe fe-trash"></i></a>
                         <span class="dropdown dropstart">
-                                <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
-                                  <i class="fe fe-more-vertical"></i>
-                                </a>
-                                <span class="dropdown-menu">
-                                  <span class="dropdown-header">Settings</span>
-                                                        <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i>Edit</a>
-                                                        <a class="dropdown-item" href="#"><i class="fe fe-trash dropdown-item-icon"></i>Remove</a>
-                                                        </span>
-                                                        </span>
+                          <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
+                            <i class="fe fe-more-vertical"></i>
+                          </a>
+                          <span class="dropdown-menu">
+                            <span class="dropdown-header">Settings</span>
+                              <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i> Edit</a>
+                              <% if staff.deactivated_at %>
+                                <%= button_to staff_activate_path(staff), class: "dropdown-item" do %>
+                                  <i class="fe fe-unlock dropdown-item-icon"></i> Activate
+                                <% end %>
+                              <% else %>
+                                <%= button_to staff_deactivate_path(staff), class: "dropdown-item" do %>
+                                  <i class="fe fe-lock  dropdown-item-icon"></i> Deactivate
+                                <% end %>
+                              <% end %>
+                            </span>
+                          </span>
                       </div>
                     </td>
                   </tr>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -9,6 +9,7 @@ en:
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."
+      deactivated: "Your account is deacivated."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,3 +211,4 @@ en:
     status:
       invitation_sent: "Invitation sent"
       enabled: "Enabled"
+      deactivated: "Deactivated"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,10 @@ Rails.application.routes.draw do
     resources :adoption_application_reviews, only: [:index, :edit, :update]
     resources :foster_application_reviews, only: [:index]
     resources :settings, only: [:index]
-    resources :staff
+    resources :staff do
+      post "deactivate", to: "staff#deactivate"
+      post "activate", to: "staff#activate"
+    end
   end
 
   resources :profile_reviews, only: [:show]

--- a/db/migrate/20231019115817_add_deactivated_at_to_staff_accounts.rb
+++ b/db/migrate/20231019115817_add_deactivated_at_to_staff_accounts.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedAtToStaffAccounts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :staff_accounts, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_132343) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_19_115817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -211,6 +211,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_132343) do
     t.bigint "organization_id", default: 1, null: false
     t.boolean "verified", default: false, null: false
     t.bigint "user_id", default: 0, null: false
+    t.datetime "deactivated_at"
     t.index ["organization_id"], name: "index_staff_accounts_on_organization_id"
     t.index ["user_id"], name: "index_staff_accounts_on_user_id"
   end

--- a/test/integration/organizations/deactivate_activate_staff_test.rb
+++ b/test/integration/organizations/deactivate_activate_staff_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Organizations::DeactivateActivateStaffTest < ActionDispatch::IntegrationTest
+  test "staff admin can deactivate other staff" do
+    admin = create(:user, :staff_admin)
+    set_organization(admin.organization)
+    sign_in admin
+    staff = create(:staff_account)
+
+    post(staff_deactivate_url(staff.id))
+
+    assert_response :redirect
+    assert staff.reload.deactivated_at
+  end
+
+  test "staff admin can activate deactivated staff" do
+    admin = create(:user, :staff_admin)
+    set_organization(admin.organization)
+    sign_in admin
+    staff = create(:staff_account, deactivated_at: Time.now)
+
+    post(staff_activate_url(staff.id))
+
+    assert_response :redirect
+    assert_nil staff.reload.deactivated_at
+  end
+
+  test "staff admin cannot deactivate himself" do
+    admin = create(:user, :staff_admin)
+    set_organization(admin.organization)
+    sign_in admin
+
+    post(staff_deactivate_url(admin.staff_account.id))
+
+    assert_response :redirect
+    assert_not admin.staff_account.reload.deactivated_at
+  end
+end

--- a/test/models/staff_account_test.rb
+++ b/test/models/staff_account_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StaffAccountTest < ActiveSupport::TestCase
+  context "#deactivate" do
+    should "set deactivated_at" do
+      staff_account = create(:staff_account)
+
+      staff_account.deactivate
+      assert_not_nil(staff_account.deactivated_at)
+    end
+  end
+
+  context "#activate" do
+    should "set deactivated_at to nil" do
+      staff_account = create(:staff_account)
+
+      staff_account.activate
+      assert_nil(staff_account.deactivated_at)
+    end
+  end
+end


### PR DESCRIPTION
# 🔗 Issue
Fixes #169 

# ✍️ Description
This PR implements activating and deactivating staff by staff admin. When staff is deactivated they cannot log in. Staff admin cannot deactivate themself because they are logged out immediately and won't be able to activate themself. 

# 📷 Screenshots/Demos

https://github.com/rubyforgood/pet-rescue/assets/96994176/5a25959a-bace-4ce4-a3a7-79bad7c5015a


