### PR TITLE
Improve tests stability

### DIFF
--- a/app/models/organization_profile.rb
+++ b/app/models/organization_profile.rb
@@ -23,7 +23,7 @@
 #
 class OrganizationProfile < ApplicationRecord
   belongs_to :location
-  belongs_to :organization
+  belongs_to :organization, inverse_of: :profile
 
   accepts_nested_attributes_for :location
   validates_associated :location

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require_dependency "acts_as_tenant/test_tenant_middleware"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -71,4 +72,7 @@ Rails.application.configure do
     default: {altatest: "hello@#{alta_from_domain}", test: "hello@#{test_from_domain}"},
     contact: {altatest: "contact@#{alta_from_domain}", test: "contact@#{test_from_domain}"}
   }
+
+  # Handle ActsAsTenant.test_tenant properly in request specs
+  config.middleware.use ActsAsTenant::TestTenantMiddleware
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,11 +1,19 @@
 FactoryBot.define do
   factory :adopter_account do
-    user
+    transient do
+      organization {}
+    end
+
+    user do
+      if organization
+        association :user, organization: organization
+      else
+        association :user
+      end
+    end
 
     trait :with_adopter_profile do
-      after :create do |account|
-        create(:adopter_profile, adopter_account: account)
-      end
+      adopter_profile { association :adopter_profile, adopter_account: instance}
     end
   end
 
@@ -81,16 +89,14 @@ FactoryBot.define do
     zipcode { Faker::Address.zip_code }
 
     trait :with_adopter_profile do
-      after :create do |location|
-        create(:adopter_profile, location: location)
-      end
+      adopter_profile
     end
   end
 
   factory :organization do
     name { Faker::Company.name }
     sequence(:slug) { |n| Faker::Internet.domain_word + n.to_s }
-    profile { build(:organization_profile) }
+    profile { association :organization_profile, organization: instance }
   end
 
   factory :organization_profile do
@@ -98,12 +104,7 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.phone_number }
     about_us { Faker::Lorem.paragraph(sentence_count: 4) }
     location
-
-    trait :with_organization do
-      after :build do |profile|
-        profile.organization = create(:organization, profile: profile)
-      end
-    end
+    organization { association :organization, profile: instance }
   end
 
   factory :pet do
@@ -133,23 +134,21 @@ FactoryBot.define do
     end
 
     trait :adopted do
-      after :create do |pet|
-        create :match, pet: pet, organization: pet.organization
-      end
+      match { association :match, organization: organization }
     end
   end
 
   factory :match do
     organization
-    pet { create(:pet, organization: organization) }
-    association :adopter_account, factory: [:adopter_account, :with_adopter_profile]
+    pet { association :pet, organization: organization }
+    adopter_account { association :adopter_account, :with_adopter_profile, organization: organization }
   end
 
   factory :staff_account do
     verified { true }
 
     organization
-    user
+    user { association :user, organization: organization}
 
     trait :unverified do
       verified { false }
@@ -173,15 +172,15 @@ FactoryBot.define do
     organization
 
     trait :verified_staff do
-      staff_account
+      staff_account { association :staff_account, organization: organization}
     end
 
     trait :staff_admin do
-      association(:staff_account, :admin)
+      staff_account { association :staff_account, :admin, organization: organization}
     end
 
     trait :unverified_staff do
-      staff_account { build(:staff_account, :unverified) }
+      staff_account { association :staff_account, :unverified, organization: organization}
     end
 
     trait :adopter_without_profile do
@@ -189,20 +188,7 @@ FactoryBot.define do
     end
 
     trait :adopter_with_profile do
-      adopter_account
-
-      after :create do |user|
-        create :adopter_profile, adopter_account: user.adopter_account
-      end
-    end
-
-    trait :application_awaiting_review do
-      adopter_account
-
-      after :create do |user|
-        create :adopter_application, adopter_account: user.adopter_account, status: 0
-        user.adopter_account.adopter_profile = create(:adopter_profile)
-      end
+      association :adopter_account, :with_adopter_profile
     end
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :adopter_account do
     transient do
-      organization {}
+      organization { ActsAsTenant.current_tenant }
     end
 
     user do
@@ -104,7 +104,7 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.phone_number }
     about_us { Faker::Lorem.paragraph(sentence_count: 4) }
     location
-    organization { association :organization, profile: instance }
+    organization { ActsAsTenant.current_tenant }
   end
 
   factory :pet do
@@ -117,7 +117,7 @@ FactoryBot.define do
     weight_to { 20 }
     weight_unit { "lb" }
     species { Faker::Number.within(range: 0..1) }
-    organization
+    organization { ActsAsTenant.current_tenant }
 
     trait :adoption_pending do
       adopter_applications { build_list(:adopter_application, 3, :adoption_pending) }
@@ -139,7 +139,7 @@ FactoryBot.define do
   end
 
   factory :match do
-    organization
+    organization { ActsAsTenant.current_tenant }
     pet { association :pet, organization: organization }
     adopter_account { association :adopter_account, :with_adopter_profile, organization: organization }
   end
@@ -147,7 +147,7 @@ FactoryBot.define do
   factory :staff_account do
     verified { true }
 
-    organization
+    organization { ActsAsTenant.current_tenant }
     user { association :user, organization: organization}
 
     trait :unverified do
@@ -169,7 +169,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     tos_agreement { true }
 
-    organization
+    organization { ActsAsTenant.current_tenant }
 
     trait :verified_staff do
       staff_account { association :staff_account, organization: organization}

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -89,7 +89,7 @@ FactoryBot.define do
 
   factory :organization do
     name { Faker::Company.name }
-    slug { Faker::Internet.domain_word }
+    sequence(:slug) { |n| Faker::Internet.domain_word + n.to_s }
     profile { build(:organization_profile) }
   end
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :adopter_account do
     transient do
-      organization { ActsAsTenant.current_tenant }
+      organization { ActsAsTenant.test_tenant }
     end
 
     user do
@@ -104,7 +104,7 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.phone_number }
     about_us { Faker::Lorem.paragraph(sentence_count: 4) }
     location
-    organization { ActsAsTenant.current_tenant }
+    organization { ActsAsTenant.test_tenant }
   end
 
   factory :pet do
@@ -117,7 +117,7 @@ FactoryBot.define do
     weight_to { 20 }
     weight_unit { "lb" }
     species { Faker::Number.within(range: 0..1) }
-    organization { ActsAsTenant.current_tenant }
+    organization { ActsAsTenant.test_tenant }
 
     trait :adoption_pending do
       adopter_applications { build_list(:adopter_application, 3, :adoption_pending) }
@@ -139,7 +139,7 @@ FactoryBot.define do
   end
 
   factory :match do
-    organization { ActsAsTenant.current_tenant }
+    organization { ActsAsTenant.test_tenant }
     pet { association :pet, organization: organization }
     adopter_account { association :adopter_account, :with_adopter_profile, organization: organization }
   end
@@ -147,7 +147,7 @@ FactoryBot.define do
   factory :staff_account do
     verified { true }
 
-    organization { ActsAsTenant.current_tenant }
+    organization { ActsAsTenant.test_tenant }
     user { association :user, organization: organization}
 
     trait :unverified do
@@ -169,7 +169,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     tos_agreement { true }
 
-    organization { ActsAsTenant.current_tenant }
+    organization { ActsAsTenant.test_tenant }
 
     trait :verified_staff do
       staff_account { association :staff_account, organization: organization}

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     end
 
     trait :with_adopter_profile do
-      adopter_profile { association :adopter_profile, adopter_account: instance}
+      adopter_profile { association :adopter_profile, adopter_account: instance }
     end
   end
 
@@ -148,7 +148,7 @@ FactoryBot.define do
     verified { true }
 
     organization { ActsAsTenant.test_tenant }
-    user { association :user, organization: organization}
+    user { association :user, organization: organization }
 
     trait :unverified do
       verified { false }
@@ -172,15 +172,15 @@ FactoryBot.define do
     organization { ActsAsTenant.test_tenant }
 
     trait :verified_staff do
-      staff_account { association :staff_account, organization: organization}
+      staff_account { association :staff_account, organization: organization }
     end
 
     trait :staff_admin do
-      staff_account { association :staff_account, :admin, organization: organization}
+      staff_account { association :staff_account, :admin, organization: organization }
     end
 
     trait :unverified_staff do
-      staff_account { association :staff_account, :unverified, organization: organization}
+      staff_account { association :staff_account, :unverified, organization: organization }
     end
 
     trait :adopter_without_profile do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -162,7 +162,7 @@ FactoryBot.define do
   end
 
   factory :user do
-    email { Faker::Internet.email }
+    sequence(:email) { |n| "john-#{n}@example.com" }
     password { "123456" }
     encrypted_password { Devise::Encryptor.digest(User, "123456") }
     first_name { Faker::Name.first_name }

--- a/test/integration/adoptable_pet_show_test.rb
+++ b/test/integration/adoptable_pet_show_test.rb
@@ -37,8 +37,8 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
   test "adopter application sees application status" do
     skip("while new ui is implemented")
     # pet = create(:pet, :adoption_pending)
-    # user = create(:user, :application_awaiting_review)
-    # user.adopter_account.adopter_applications[0].update(pet: pet)
+    # user = create(:user, :adopter_with_profile, organization: pet.organization)
+    # create(:adopter_application, adopter_account: user.adopter_account, pet: pet, status: :awaiting_review)
     # sign_in user
 
     # get "/adoptable_pets/#{pet.id}"

--- a/test/integration/organizations/invite_staff_test.rb
+++ b/test/integration/organizations/invite_staff_test.rb
@@ -10,13 +10,12 @@ class Organizations::InviteStaffTest < ActionDispatch::IntegrationTest
         staff_account_attributes: {roles: "admin"}
       }
     }
+    admin = create(:user, :staff_admin)
+    set_organization(admin.organization)
+    sign_in admin
   end
 
   test "staff admin can invite other staffs to the organization" do
-    admin = create(:user, :staff_admin)
-    sign_in admin
-    set_organization(admin.organization)
-
     post(
       user_invitation_path,
       params: @user_invitation_params
@@ -34,9 +33,6 @@ class Organizations::InviteStaffTest < ActionDispatch::IntegrationTest
   end
 
   test "staff admin can not invite existing user to the organization" do
-    admin = create(:user, :staff_admin)
-    sign_in admin
-    set_organization(admin.organization)
     _existing_user = create(:user, email: "john@example.com")
 
     post(

--- a/test/models/checklist_assignment_test.rb
+++ b/test/models/checklist_assignment_test.rb
@@ -2,13 +2,11 @@ require "test_helper"
 
 class ChecklistAssignmentTest < ActiveSupport::TestCase
   test "assigning checklist to match" do
-    organization = create(:organization)
-    pet = create(:pet, :adopted, organization: organization)
+    pet = create(:pet, :adopted)
     match = create(
       :match,
       adopter_account: create(:adopter_account),
-      pet: pet,
-      organization: organization
+      pet: pet
     )
     checklist = create(:checklist_template)
 

--- a/test/models/organization_profile_test.rb
+++ b/test/models/organization_profile_test.rb
@@ -9,7 +9,7 @@ class OrganizationProfileTest < ActiveSupport::TestCase
   end
 
   context "callbacks" do
-    subject { build(:organization_profile, :with_organization) }
+    subject { build(:organization_profile) }
 
     should "call normalize phone when saving" do
       assert subject.expects(:normalize_phone).at_least_once

--- a/test/system/login_test.rb
+++ b/test/system/login_test.rb
@@ -2,9 +2,8 @@ require "application_system_test_case"
 
 class LoginTest < ApplicationSystemTestCase
   setup do
-    @organization = create(:organization)
-    @user = create(:user, organization: @organization)
-    StaffAccount.create!(user: @user, organization: @organization, verified: true)
+    @user = create(:user, :verified_staff)
+    @organization = @user.organization
     set_organization(@organization)
   end
 
@@ -17,7 +16,7 @@ class LoginTest < ApplicationSystemTestCase
       fill_in "Password", with: @user.password
       click_on "Log in"
 
-      assert current_path.include?(@user.organization.slug)
+      assert current_path.include?(@organization.slug)
       assert_equal current_path, dashboard_index_path
     end
   end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -2,9 +2,8 @@ require "application_system_test_case"
 
 class UsersTest < ApplicationSystemTestCase
   setup do
-    @organization = create(:organization)
-    @user = create(:user, organization: @organization)
-    StaffAccount.create!(user: @user, organization: @organization, verified: true)
+    @user = create(:user, :verified_staff)
+    @organization = @user.organization
     set_organization(@organization)
   end
 
@@ -16,7 +15,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in "Password", with: @user.password
     click_on "Log in"
 
-    assert current_path.include?(@user.organization.slug)
+    assert current_path.include?(@organization.slug)
     assert_equal current_path, dashboard_index_path
 
     using_wait_time(5) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ class ActiveSupport::TestCase
     Rails.application.routes.default_url_options[:script_name] = "/#{organization.slug}"
   end
 
-  def setup
+  setup do
     ActsAsTenant.current_tenant = create(:organization, slug: "test")
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,11 +27,11 @@ class ActiveSupport::TestCase
   end
 
   setup do
-    ActsAsTenant.current_tenant = create(:organization, slug: "test")
+    ActsAsTenant.test_tenant = create(:organization, slug: "test")
   end
 
   def teardown
-    ActsAsTenant.current_tenant = nil
+    ActsAsTenant.test_tenant = nil
     Rails.application.routes.default_url_options[:script_name] = ""
   end
 


### PR DESCRIPTION
# ✍️ Description
This PR addresses some inconsistencies in our test suite to enhance its stability and the overall developer experience. 

Here's a summary of the improvements made:
1. Changed the `setup` function in test_helper.rb to ensure it is called before the `setup` block in individual test files.
2. Resolved issues of Organizations generated with factories having duplicate slugs.
3. Clarified interconnected associations in factories to ensure consistency:
  ```
  match = create(:match)
  match.organization == match.pet.organization # => now true
```
4. Resolved issues of Users generated with factories having duplicate emails.
5. Streamlined the behavior of factories with ActsAsTenant:
```
user = create(:user)
user.organization == ActsAsTenant.test_tenant # => true
Organization.count # => 1 (was 2 before the fix)
```
6. Reconfigured ActsAsTenant for tests according to the [docs](https://github.com/ErwinM/acts_as_tenant#testing)
