### PR TITLE
Remove default values from foreign keys

### DIFF
--- a/app/controllers/organizations/invitations_controller.rb
+++ b/app/controllers/organizations/invitations_controller.rb
@@ -1,4 +1,7 @@
 class Organizations::InvitationsController < Devise::InvitationsController
+  include OrganizationScopable
+  # TODO: remove next line once we fix links in the invitation emails
+  skip_before_action :set_tenant, except: [:new, :create]
   before_action :require_organization_admin, only: [:new, :create]
   layout "dashboard", only: [:new, :create]
 

--- a/app/models/adopter_account.rb
+++ b/app/models/adopter_account.rb
@@ -5,7 +5,7 @@
 #  id         :bigint           not null, primary key
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  user_id    :bigint           default(0), not null
+#  user_id    :bigint           not null
 #
 # Indexes
 #

--- a/app/models/staff_account.rb
+++ b/app/models/staff_account.rb
@@ -7,8 +7,8 @@
 #  verified        :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  organization_id :bigint           default(1), not null
-#  user_id         :bigint           default(0), not null
+#  organization_id :bigint           not null
+#  user_id         :bigint           not null
 #
 # Indexes
 #

--- a/db/migrate/20231023113924_remove_default_values.rb
+++ b/db/migrate/20231023113924_remove_default_values.rb
@@ -1,0 +1,7 @@
+class RemoveDefaultValues < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default(:adopter_accounts, :user_id, nil)
+    change_column_default(:staff_accounts, :organization_id, nil)
+    change_column_default(:staff_accounts, :user_id, nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_19_155058) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_23_113924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,7 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_19_155058) do
   create_table "adopter_accounts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", default: 0, null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_adopter_accounts_on_user_id"
   end
 
@@ -209,9 +209,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_19_155058) do
   create_table "staff_accounts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "organization_id", default: 1, null: false
+    t.bigint "organization_id", null: false
     t.boolean "verified", default: false, null: false
-    t.bigint "user_id", default: 0, null: false
+    t.bigint "user_id", null: false
     t.datetime "deactivated_at"
     t.index ["organization_id"], name: "index_staff_accounts_on_organization_id"
     t.index ["user_id"], name: "index_staff_accounts_on_user_id"

--- a/test/integration/organizations/invite_staff_test.rb
+++ b/test/integration/organizations/invite_staff_test.rb
@@ -13,7 +13,9 @@ class Organizations::InviteStaffTest < ActionDispatch::IntegrationTest
   end
 
   test "staff admin can invite other staffs to the organization" do
-    sign_in create(:user, :staff_admin)
+    admin = create(:user, :staff_admin)
+    sign_in admin
+    set_organization(admin.organization)
 
     post(
       user_invitation_path,
@@ -32,7 +34,9 @@ class Organizations::InviteStaffTest < ActionDispatch::IntegrationTest
   end
 
   test "staff admin can not invite existing user to the organization" do
-    sign_in create(:user, :staff_admin)
+    admin = create(:user, :staff_admin)
+    sign_in admin
+    set_organization(admin.organization)
     _existing_user = create(:user, email: "john@example.com")
 
     post(


### PR DESCRIPTION
# 🔗 Issue
Fixes #297 

# ✍️ Description
I removed default values from: 
- adopter_accounts.user_id,
- staff_accounts.organization_id,
- staff_accounts.user_id
