### PR TITLE
Modify staff login to redirect to pets#index

### DIFF
--- a/app/controllers/concerns/organization_scopable.rb
+++ b/app/controllers/concerns/organization_scopable.rb
@@ -16,7 +16,7 @@ module OrganizationScopable
 
   def after_sign_in_path_for(resource_or_scope)
     if resource_or_scope.staff_account&.verified
-      dashboard_index_path
+      pets_path
     else
       adoptable_pets_path
     end

--- a/test/system/login_test.rb
+++ b/test/system/login_test.rb
@@ -8,7 +8,7 @@ class LoginTest < ApplicationSystemTestCase
   end
 
   context "when logging in as a staff member" do
-    should "direct to the organization's dashboard" do
+    should "direct to the organization's pets index view" do
       visit root_url
       click_on "Log In"
 
@@ -17,7 +17,7 @@ class LoginTest < ApplicationSystemTestCase
       click_on "Log in"
 
       assert current_path.include?(@organization.slug)
-      assert_equal current_path, dashboard_index_path
+      assert_equal current_path, pets_path
     end
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -16,7 +16,7 @@ class UsersTest < ApplicationSystemTestCase
     click_on "Log in"
 
     assert current_path.include?(@organization.slug)
-    assert_equal current_path, dashboard_index_path
+    assert_equal current_path, pets_path
 
     using_wait_time(5) do
       find("#dropdownUser").hover


### PR DESCRIPTION
# 🔗 Issue
Resolves #305

# ✍️ Description
After successful login, staff are redirected to /pets (pets#index view). The previous behaviour redirected to the organization's dashboard.