### PR TITLE
#304 Allow to set species on pet create/edit form

### DIFF
--- a/app/controllers/organizations/pets_controller.rb
+++ b/app/controllers/organizations/pets_controller.rb
@@ -65,6 +65,7 @@ class Organizations::PetsController < Organizations::BaseController
       :name,
       :birth_date,
       :sex,
+      :species,
       :breed,
       :description,
       :application_paused,

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -38,6 +38,7 @@ class Pet < ApplicationRecord
   validates :birth_date, presence: true
   validates :breed, presence: true
   validates :sex, presence: true
+  validates :species, presence: true
   validates :weight_from, presence: true, numericality: {only_integer: true}
   validates :weight_to, presence: true, numericality: {only_integer: true}
   validates :weight_unit, presence: true

--- a/app/views/organizations/pets/_form.html.erb
+++ b/app/views/organizations/pets/_form.html.erb
@@ -31,6 +31,13 @@
       </div>
 
       <div class='form-group'>
+        <%= form.select :species, 
+                        options_for_select(Pet.species.keys, selected: pet.species), 
+                        { prompt: t('general.please_select') }, 
+                        class: 'form-control' %>
+      </div>
+
+      <div class='form-group'>
         <%= form.text_field :breed, class: 'form-control' %>
       </div>
 

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -14,6 +14,7 @@ class PetTest < ActiveSupport::TestCase
     should validate_presence_of(:birth_date)
     should validate_presence_of(:breed)
     should validate_presence_of(:sex)
+    should validate_presence_of(:species)
     should validate_presence_of(:description)
     should validate_length_of(:description).is_at_most(1000)
     should validate_presence_of(:weight_from)


### PR DESCRIPTION

# 🔗 Issue
<!-- Add link to the issue -->
[#304](https://github.com/rubyforgood/pet-rescue/issues/304)

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Added species select field between sex and breed, updated pet strong params. I also added validates presence of species to the model and to pet test. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
![pet_new](https://github.com/rubyforgood/pet-rescue/assets/82609260/e8343dde-31d5-4292-8a09-7748c40f1348)
![pet_edit](https://github.com/rubyforgood/pet-rescue/assets/82609260/39206960-113a-4bd2-b4e3-b963b8da4eae)

