### PR TITLE
Give pet status column more contrast in the pets index table (#325)

### DIFF
--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -83,7 +83,7 @@
                 <%= "#{pet.weight_from} - #{pet.weight_to} #{pet.weight_unit}" %>
               </td>
               <td>
-                <span class="badge bg-info-soft"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
+                <span class="badge bg-gray-700"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
               </td>
               <% if current_user.staff_account %>
                 <td>


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
[#325](https://github.com/rubyforgood/pet-rescue/issues/325)

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Changed pet status column background color to dark gray.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
<img width="917" alt="Screenshot 2023-11-04 at 1 17 20 PM" src="https://github.com/rubyforgood/pet-rescue/assets/82609260/c0eb1386-4a5a-4638-9bfc-78df9c4f03d0">

