### PR TITLE
Remove margin from dashboard layout

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -8,7 +8,7 @@
       <%= render "layouts/dashboard/sidebar" %>
 
       <!-- Page Content -->
-      <main id="page-content">
+      <main class="container-md">
         <div class="header">
           <!-- navbar -->
           <nav class="navbar-default navbar navbar-expand-lg">

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -83,7 +83,7 @@
                 <%= "#{pet.weight_from} - #{pet.weight_to} #{pet.weight_unit}" %>
               </td>
               <td>
-                <span class="badge bg-info-soft"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
+                <span class="badge bg-gray-700"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
               </td>
               <% if current_user.staff_account %>
                 <td>


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Removes large margin from dashboard layout. 

It's not perfect. Right around 800px, there is a little bit of overflow that is causing the rightmost icon in the navbar to be cut off (I included a screenshot of the issue so you can see). This is being caused by the table, although I am uncertain what exactly about the table is causing it. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

Desktop: 

<img width="1373" alt="Screenshot 2023-11-04 at 6 27 34 PM" src="https://github.com/rubyforgood/pet-rescue/assets/82609260/4f2e440d-213b-46f6-81ce-ccbf0dbff32e">

Mobile: 

<img width="603" alt="Screenshot 2023-11-04 at 6 27 53 PM" src="https://github.com/rubyforgood/pet-rescue/assets/82609260/c2b56575-e6bb-4f6d-9528-545f47fcffe9">

800px weirdness: 

<img width="480" alt="Screenshot 2023-11-04 at 5 26 57 PM" src="https://github.com/rubyforgood/pet-rescue/assets/82609260/d02a2776-ec87-4e0b-add8-1b9448518523">




