### PR TITLE
Replace sidebar image with current organization name

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,12 @@ module ApplicationHelper
   def organization_home_path(organization)
     home_index_path(script_name: "/#{organization.slug}")
   end
+
+  def current_organization_name
+    if Current.organization.present?
+      Current.organization.name
+    else
+      Current.tenant.name
+    end
+  end
 end

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -1,9 +1,9 @@
 <nav class="navbar navbar-vertical">
   <div class="vh-100" data-simplebar>
     <!-- Brand logo -->
-    <a class="navbar-brand">
-      <img src="" alt="">
-    </a>
+    <p class="navbar-brand flex-column">
+      <%= current_organization_name %>
+    </p>
 
     <!-- Navbar nav -->
     <ul class="navbar-nav flex-column" id="sideNavbar">


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/199

# ✍️ Description
- Created new helper method to display current `organization.name` or `tenant.name`
- Replaced `<a>` tag with `<p>`in order to display name

# 📷 Screenshots/Demos
https://jam.dev/c/593bece9-2e68-4f2f-8fe1-3f9037d5bbe6

<img width="1521" alt="image" src="https://github.com/rubyforgood/pet-rescue/assets/10580258/9a94a6b9-6d6a-4b22-9e68-961402c864af"><!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
