### PR TITLE
Revert "Remove margin from dashboard layout"

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -8,7 +8,7 @@
       <%= render "layouts/dashboard/sidebar" %>
 
       <!-- Page Content -->
-      <main class="container-md">
+      <main id="page-content">
         <div class="header">
           <!-- navbar -->
           <nav class="navbar-default navbar navbar-expand-lg">

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -83,7 +83,7 @@
                 <%= "#{pet.weight_from} - #{pet.weight_to} #{pet.weight_unit}" %>
               </td>
               <td>
-                <span class="badge bg-gray-700"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
+                <span class="badge bg-info-soft"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
               </td>
               <% if current_user.staff_account %>
                 <td>


### PR DESCRIPTION
Reverts rubyforgood/pet-rescue#331

This 'fix' for the dashboard no longer works on the contributor's machine so it's not likely a long-term sustainable fix.