### PR TITLE
Fix seed file

### DIFF
--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -243,7 +243,7 @@ ActsAsTenant.with_tenant(@organization) do
       notes: Faker::Lorem.paragraph,
       profile_show: true,
       status: rand(0..5),
-      adopter_account: AdopterAccount.joins(:user).where(users: { organization_id: @organization.id }).sample,
+      adopter_account: AdopterAccount.joins(:user).where(users: {organization_id: @organization.id}).sample,
       pet: Pet.all.sample
     )
   end

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -5,13 +5,13 @@ orga_location = Location.create!(
   zipcode: "12345"
 )
 
-organization = Organization.create!(
+@organization = Organization.create!(
   name: "Alta Pet Rescue",
   slug: "alta",
   profile: OrganizationProfile.new(email: "alta@email.com", phone_number: "123 456 7890", location: orga_location, about_us: "We get pets into loving homes!")
 )
 
-ActsAsTenant.with_tenant(organization) do
+ActsAsTenant.with_tenant(@organization) do
   @user_staff_one = User.create!(
     email: "staff@alta.com",
     first_name: "Andy",
@@ -243,7 +243,7 @@ ActsAsTenant.with_tenant(organization) do
       notes: Faker::Lorem.paragraph,
       profile_show: true,
       status: rand(0..5),
-      adopter_account: AdopterAccount.all.sample,
+      adopter_account: AdopterAccount.joins(:user).where(users: { organization_id: @organization.id }).sample,
       pet: Pet.all.sample
     )
   end

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -243,7 +243,7 @@ ActsAsTenant.with_tenant(@organization) do
       notes: Faker::Lorem.paragraph,
       profile_show: true,
       status: rand(0..5),
-      adopter_account: AdopterAccount.joins(:user).where(users: { organization_id: @organization.id }).sample,
+      adopter_account: AdopterAccount.joins(:user).where(users: {organization_id: @organization.id}).sample,
       pet: Pet.all.sample
     )
   end

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -5,12 +5,13 @@ orga_location = Location.create!(
   zipcode: "12346"
 )
 
-organization = Organization.create!(
+@organization = Organization.create!(
   name: "Baja",
   slug: "baja",
   profile: OrganizationProfile.new(email: "baja@email.com", phone_number: "123 456 7891", location: orga_location, about_us: "We help pets find their forever homes!")
 )
-ActsAsTenant.with_tenant(organization) do
+
+ActsAsTenant.with_tenant(@organization) do
   @user_staff_one = User.create!(
     email: "staff@baja.com",
     first_name: "Andy",
@@ -242,7 +243,7 @@ ActsAsTenant.with_tenant(organization) do
       notes: Faker::Lorem.paragraph,
       profile_show: true,
       status: rand(0..5),
-      adopter_account: AdopterAccount.all.sample,
+      adopter_account: AdopterAccount.joins(:user).where(users: { organization_id: @organization.id }).sample,
       pet: Pet.all.sample
     )
   end


### PR DESCRIPTION

# 🔗 Issue
n/a

# ✍️ Description
A quick fix to the seeds to make sure when we are creating the adopter applications that they are scoped to adopter_accounts in the same organization. The current approach will cause some adopter applications in Baja org to belong to adopter accounts in Alta org because it is not limiting the query to just adtoper accounts scoped to Baja. This was found during review of this PR https://github.com/rubyforgood/pet-rescue/pull/338

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
