### PR TITLE
Fix mobile navbar dropdowns

### DIFF
--- a/app/components/avatar_component.rb
+++ b/app/components/avatar_component.rb
@@ -32,11 +32,11 @@ class AvatarComponent < ViewComponent::Base
   end
 
   def avatar_with_image
-    image_tag @system_arguments[:src], class: @classes, alt: @alt
+    image_tag @system_arguments[:src], class: @classes, 'data-bs-toggle' => 'dropdown', alt: @alt
   end
 
   def avatar_with_initials
-    tag.div(tag.span(@alt), class: @classes, style: "background-color: #{avatar_color(@alt)}; display: flex; align-items: center; justify-content: center;")
+    tag.div(tag.span(@alt), class: @classes, 'data-bs-toggle' => 'dropdown', style: "background-color: #{avatar_color(@alt)}; display: flex; align-items: center; justify-content: center;")
   end
 
   def avatar_color(text)

--- a/app/components/avatar_component.rb
+++ b/app/components/avatar_component.rb
@@ -32,11 +32,11 @@ class AvatarComponent < ViewComponent::Base
   end
 
   def avatar_with_image
-    image_tag @system_arguments[:src], class: @classes, 'data-bs-toggle' => 'dropdown', alt: @alt
+    image_tag @system_arguments[:src], :class => @classes, "data-bs-toggle" => "dropdown", :alt => @alt
   end
 
   def avatar_with_initials
-    tag.div(tag.span(@alt), class: @classes, 'data-bs-toggle' => 'dropdown', style: "background-color: #{avatar_color(@alt)}; display: flex; align-items: center; justify-content: center;")
+    tag.div(tag.span(@alt), :class => @classes, "data-bs-toggle" => "dropdown", :style => "background-color: #{avatar_color(@alt)}; display: flex; align-items: center; justify-content: center;")
   end
 
   def avatar_color(text)

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -81,12 +81,14 @@
         <li class='nav-item'>
           <%= active_link_to 'Partners', partners_path, class: 'nav-link' %>
         </li>
+        <% unless user_signed_in? %>
         <li class="nav-item d-block d-md-none">
           <%= active_link_to 'Adopt', new_user_registration_path, class: 'nav-link' %>
         </li>
         <li class="nav-item d-block d-md-none">
           <%= active_link_to 'Log In', new_user_session_path, class: 'nav-link' %>
         </li>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/test/system/user_mobile_test.rb
+++ b/test/system/user_mobile_test.rb
@@ -1,4 +1,4 @@
-require 'application_system_test_case'
+require "application_system_test_case"
 
 class UsersMobileTest < ApplicationSystemTestCase
   setup do
@@ -8,32 +8,32 @@ class UsersMobileTest < ApplicationSystemTestCase
     current_window.resize_to(375, 800)
   end
 
-  test 'user can log out mobile' do
+  test "user can log out mobile" do
     visit root_url
-    click_on 'Log In'
+    click_on "Log In"
 
-    fill_in 'Email', with: @user.email
-    fill_in 'Password', with: @user.password
-    click_on 'Log in'
+    fill_in "Email", with: @user.email
+    fill_in "Password", with: @user.password
+    click_on "Log in"
 
     assert current_path.include?(@organization.slug)
     assert_equal current_path, pets_path
 
     using_wait_time(5) do
-      find('.avatar').click
+      find(".avatar").click
     end
 
-    click_on 'Sign Out'
+    click_on "Sign Out"
 
-    assert_text 'Signed out successfully'
+    assert_text "Signed out successfully"
   end
 
-  test 'non-authenticated user attempts to log out mobile' do
+  test "non-authenticated user attempts to log out mobile" do
     visit root_url
-    refute has_button?('Sign out')
-    expected_path = '/' + @organization.slug + '/home'
+    refute has_button?("Sign out")
+    expected_path = "/" + @organization.slug + "/home"
     assert_equal current_path, expected_path
-    assert_text 'Rescue a really cute pet and be a hero'
+    assert_text "Rescue a really cute pet and be a hero"
   end
   teardown do
     current_window.resize_to(1200, 762)

--- a/test/system/user_mobile_test.rb
+++ b/test/system/user_mobile_test.rb
@@ -1,0 +1,41 @@
+require 'application_system_test_case'
+
+class UsersMobileTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:user, :verified_staff)
+    @organization = @user.organization
+    set_organization(@organization)
+    current_window.resize_to(375, 800)
+  end
+
+  test 'user can log out mobile' do
+    visit root_url
+    click_on 'Log In'
+
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: @user.password
+    click_on 'Log in'
+
+    assert current_path.include?(@organization.slug)
+    assert_equal current_path, pets_path
+
+    using_wait_time(5) do
+      find('.avatar').click
+    end
+
+    click_on 'Sign Out'
+
+    assert_text 'Signed out successfully'
+  end
+
+  test 'non-authenticated user attempts to log out mobile' do
+    visit root_url
+    refute has_button?('Sign out')
+    expected_path = '/' + @organization.slug + '/home'
+    assert_equal current_path, expected_path
+    assert_text 'Rescue a really cute pet and be a hero'
+  end
+  teardown do
+    current_window.resize_to(1200, 762)
+  end
+end


### PR DESCRIPTION
#342  🔗 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
1. Add dropdown data target to Avatar which enables clicking instead of hover on mobile
2. Navbar collapse menu checks if user is logged in before displaying login/adopt menu items
3. Add tests for mobile screen size login/logout

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
![Screenshot from 2023-11-22 10-17-08](https://github.com/rubyforgood/pet-rescue/assets/16829344/46cb47d9-82ae-4851-8766-4dd55c4ef955)

![Screenshot from 2023-11-22 10-00-19](https://github.com/rubyforgood/pet-rescue/assets/16829344/99f71afa-fe3d-4933-a181-243977208bec)

