### PR TITLE
Fix layout on wide screens

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -8,7 +8,7 @@
       <%= render "layouts/dashboard/sidebar" %>
 
       <!-- Page Content -->
-      <main id="page-content">
+      <main class="container-fluid">
         <div class="header">
           <!-- navbar -->
           <nav class="navbar-default navbar navbar-expand-lg">


### PR DESCRIPTION
# ✍️ Description
The dashboard layout was broken on screens wider than 768px:
<img width="1078" alt="Screenshot 2023-11-29 at 14 55 37" src="https://github.com/rubyforgood/pet-rescue/assets/16762860/caed11d5-67bb-449c-b180-5b238ebaadba">

Now it should be displayed correctly on all screens :)
There are still some issues with the sidebar sometimes, we can fix it separately.

# 📷 Screenshots/Demos

https://github.com/rubyforgood/pet-rescue/assets/16762860/a58bbd5d-b6b1-4fcf-94d4-167c5aed1916

