### PR TITLE
Revert "Fix layout on wide screens"

### DIFF
--- a/app/views/layouts/dashboard.html.erb
+++ b/app/views/layouts/dashboard.html.erb
@@ -8,7 +8,7 @@
       <%= render "layouts/dashboard/sidebar" %>
 
       <!-- Page Content -->
-      <main class="container-fluid">
+      <main id="page-content">
         <div class="header">
           <!-- navbar -->
           <nav class="navbar-default navbar navbar-expand-lg">


### PR DESCRIPTION
Reverts rubyforgood/pet-rescue#348

Looks like it still was broken on some browsers (reported here: https://github.com/rubyforgood/pet-rescue/pull/354).
It also messed up some colors.

We need to revisit this.