### PR TITLE
WIP: As staff I can create a pet in draft so it is not visible to foster/adopters

### DIFF
--- a/app/controllers/adoptable_pets_controller.rb
+++ b/app/controllers/adoptable_pets_controller.rb
@@ -1,9 +1,9 @@
 class AdoptablePetsController < Organizations::BaseController
   def index
     @pets = Pet.includes(:adopter_applications, images_attachments: :blob)
-               .published
-               .where
-               .missing(:match)
+      .published
+      .where
+      .missing(:match)
   end
 
   def show

--- a/app/controllers/adoptable_pets_controller.rb
+++ b/app/controllers/adoptable_pets_controller.rb
@@ -1,6 +1,9 @@
 class AdoptablePetsController < Organizations::BaseController
   def index
-    @pets = Pet.includes(:adopter_applications, images_attachments: :blob).where.missing(:match)
+    @pets = Pet.includes(:adopter_applications, images_attachments: :blob)
+               .published
+               .where
+               .missing(:match)
   end
 
   def show

--- a/app/controllers/organizations/pets_controller.rb
+++ b/app/controllers/organizations/pets_controller.rb
@@ -1,101 +1,107 @@
-class Organizations::PetsController < Organizations::BaseController
-  before_action :set_pet, only: [:show, :edit, :update, :destroy]
-  before_action :verified_staff
-  before_action :set_nav_tabs, only: [:show]
+# frozen_string_literal: true
 
-  after_action :set_reason_paused_to_none, only: [:update]
-  layout "dashboard"
+module Organizations
+  class PetsController < Organizations::BaseController
+    before_action :set_pet, only: %i[show edit update destroy]
+    before_action :verified_staff
+    before_action :set_nav_tabs, only: [:show]
 
-  def index
-    @q = Pet.ransack(params[:q])
-    @pets = @q.result
-  end
+    after_action :set_reason_paused_to_none, only: [:update]
+    layout 'dashboard'
 
-  def new
-    @pet = Pet.new
-  end
-
-  def edit
-    return if pet_in_same_organization?(@pet.organization_id)
-
-    redirect_to pets_path, alert: "This pet is not in your organization."
-  end
-
-  def show
-    @active_tab = determine_active_tab
-    @pause_reason = @pet.pause_reason
-    return if pet_in_same_organization?(@pet.organization_id)
-
-    redirect_to pets_path, alert: "This pet is not in your organization."
-  end
-
-  def create
-    @pet = Pet.new(pet_params)
-
-    if @pet.save
-      redirect_to pets_path, notice: "Pet saved successfully."
-    else
-      render :new, status: :unprocessable_entity
+    def index
+      @q = Pet.ransack(params[:q])
+      @pets = @q.result
     end
-  end
 
-  def update
-    if pet_in_same_organization?(@pet.organization_id) && @pet.update(pet_params)
-      redirect_to @pet, notice: "Pet updated successfully."
-    else
-      render :edit, status: :unprocessable_entity
+    def new
+      @pet = Pet.new
     end
-  end
 
-  def destroy
-    @pet = Pet.find(params[:id])
+    def edit
+      return if pet_in_same_organization?(@pet.organization_id)
 
-    if pet_in_same_organization?(@pet.organization_id) && @pet.destroy
-      redirect_to pets_path, notice: "Pet deleted.", status: :see_other
-    else
-      redirect_to pets_path, alert: "Error."
+      redirect_to pets_path, alert: 'This pet is not in your organization.'
     end
-  end
 
-  private
+    def show
+      @active_tab = determine_active_tab
+      @pause_reason = @pet.pause_reason
+      return if pet_in_same_organization?(@pet.organization_id)
 
-  def pet_params
-    params.require(:pet).permit(:organization_id,
-      :name,
-      :birth_date,
-      :sex,
-      :species,
-      :breed,
-      :description,
-      :application_paused,
-      :pause_reason,
-      :weight_from,
-      :weight_to,
-      :weight_unit,
-      :species,
-      :placement_type,
-      append_images: [])
-  end
+      redirect_to pets_path, alert: 'This pet is not in your organization.'
+    end
 
-  def set_pet
-    @pet = Pet.find(params[:id])
-  end
+    def create
+      @pet = Pet.new(pet_params)
 
-  # update Pet pause_reason to not paused if applications resumed
-  def set_reason_paused_to_none
-    return unless @pet.application_paused == false
+      if @pet.save
+        redirect_to pets_path, notice: 'Pet saved successfully.'
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
 
-    @pet.pause_reason = 0
-    @pet.save!
-  end
+    def update
+      if pet_in_same_organization?(@pet.organization_id) && @pet.update(pet_params)
+        redirect_to @pet, notice: 'Pet updated successfully.'
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
 
-  def set_nav_tabs
-    @nav_tabs = [
-      {name: "Summary", path: pet_path(@pet)}
-    ]
-  end
+    def destroy
+      @pet = Pet.find(params[:id])
 
-  def determine_active_tab
-    ["tasks", "applications", "files"].include?(params[:active_tab]) ? params[:active_tab] : "overview"
+      if pet_in_same_organization?(@pet.organization_id) && @pet.destroy
+        redirect_to pets_path, notice: 'Pet deleted.', status: :see_other
+      else
+        redirect_to pets_path, alert: 'Error.'
+      end
+    end
+
+    private
+
+    def pet_params
+      params.require(:pet).permit(
+        :application_paused,
+        :birth_date,
+        :breed,
+        :description,
+        :is_published,
+        :name,
+        :organization_id,
+        :pause_reason,
+        :placement_type,
+        :sex,
+        :species,
+        :weight_from,
+        :weight_to,
+        :weight_unit,
+        append_images: []
+      )
+    end
+
+    def set_pet
+      @pet = Pet.find(params[:id])
+    end
+
+    # update Pet pause_reason to not paused if applications resumed
+    def set_reason_paused_to_none
+      return unless @pet.application_paused == false
+
+      @pet.pause_reason = 0
+      @pet.save!
+    end
+
+    def set_nav_tabs
+      @nav_tabs = [
+        { name: 'Summary', path: pet_path(@pet) }
+      ]
+    end
+
+    def determine_active_tab
+      %w[tasks applications files].include?(params[:active_tab]) ? params[:active_tab] : 'overview'
+    end
   end
 end

--- a/app/controllers/organizations/pets_controller.rb
+++ b/app/controllers/organizations/pets_controller.rb
@@ -7,7 +7,7 @@ module Organizations
     before_action :set_nav_tabs, only: [:show]
 
     after_action :set_reason_paused_to_none, only: [:update]
-    layout 'dashboard'
+    layout "dashboard"
 
     def index
       @q = Pet.ransack(params[:q])
@@ -21,7 +21,7 @@ module Organizations
     def edit
       return if pet_in_same_organization?(@pet.organization_id)
 
-      redirect_to pets_path, alert: 'This pet is not in your organization.'
+      redirect_to pets_path, alert: "This pet is not in your organization."
     end
 
     def show
@@ -29,14 +29,14 @@ module Organizations
       @pause_reason = @pet.pause_reason
       return if pet_in_same_organization?(@pet.organization_id)
 
-      redirect_to pets_path, alert: 'This pet is not in your organization.'
+      redirect_to pets_path, alert: "This pet is not in your organization."
     end
 
     def create
       @pet = Pet.new(pet_params)
 
       if @pet.save
-        redirect_to pets_path, notice: 'Pet saved successfully.'
+        redirect_to pets_path, notice: "Pet saved successfully."
       else
         render :new, status: :unprocessable_entity
       end
@@ -44,7 +44,7 @@ module Organizations
 
     def update
       if pet_in_same_organization?(@pet.organization_id) && @pet.update(pet_params)
-        redirect_to @pet, notice: 'Pet updated successfully.'
+        redirect_to @pet, notice: "Pet updated successfully."
       else
         render :edit, status: :unprocessable_entity
       end
@@ -54,9 +54,9 @@ module Organizations
       @pet = Pet.find(params[:id])
 
       if pet_in_same_organization?(@pet.organization_id) && @pet.destroy
-        redirect_to pets_path, notice: 'Pet deleted.', status: :see_other
+        redirect_to pets_path, notice: "Pet deleted.", status: :see_other
       else
-        redirect_to pets_path, alert: 'Error.'
+        redirect_to pets_path, alert: "Error."
       end
     end
 
@@ -96,12 +96,12 @@ module Organizations
 
     def set_nav_tabs
       @nav_tabs = [
-        { name: 'Summary', path: pet_path(@pet) }
+        {name: "Summary", path: pet_path(@pet)}
       ]
     end
 
     def determine_active_tab
-      %w[tasks applications files].include?(params[:active_tab]) ? params[:active_tab] : 'overview'
+      %w[tasks applications files].include?(params[:active_tab]) ? params[:active_tab] : "overview"
     end
   end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -7,6 +7,7 @@
 #  birth_date         :datetime         not null
 #  breed              :string
 #  description        :text
+#  is_published       :boolean          default(TRUE), not null
 #  name               :string
 #  pause_reason       :integer          default("not_paused")
 #  placement_type     :integer          not null
@@ -39,6 +40,7 @@ class Pet < ApplicationRecord
   validates :name, presence: true
   validates :birth_date, presence: true
   validates :breed, presence: true
+  validates :is_published, presence: true
   validates :sex, presence: true
   validates :species, presence: true
   validates :placement_type, presence: true

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -40,7 +40,7 @@ class Pet < ApplicationRecord
   validates :name, presence: true
   validates :birth_date, presence: true
   validates :breed, presence: true
-  validates :is_published, presence: true
+  validates :is_published, inclusion: [true, false]
   validates :sex, presence: true
   validates :species, presence: true
   validates :placement_type, presence: true

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -72,6 +72,7 @@ class Pet < ApplicationRecord
 
   scope :adopted, -> { Pet.includes(:match).where.not(match: {id: nil}) }
   scope :unadopted, -> { Pet.includes(:match).where(match: {id: nil}) }
+  scope :published, -> { where(is_published: true) }
 
   # check if pet has any applications with adoption pending status
   def has_adoption_pending?

--- a/app/views/organizations/pets/_form.html.erb
+++ b/app/views/organizations/pets/_form.html.erb
@@ -84,12 +84,10 @@
             <%= form.hidden_field :application_paused, value: false %>
             <%= form.check_box :application_paused, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" }, true, false %>
         </div>
-      </div>
 
-      <div class='form-group'>
         <div class="form-check form-switch">
           <%= form.hidden_field :is_published, value: false %>
-          <%= form.check_box :is_published, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" }, true, false %>
+          <%= form.check_box :is_published, { class: "form-check-input", role: "switch", required: false }, true, false %>
         </div>
       </div>
 

--- a/app/views/organizations/pets/_form.html.erb
+++ b/app/views/organizations/pets/_form.html.erb
@@ -80,12 +80,12 @@
       </div>
 
       <div class='form-group'>
-        <div class="form-check form-switch">
+        <div class="form-check form-switch ps-3">
             <%= form.hidden_field :application_paused, value: false %>
             <%= form.check_box :application_paused, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" }, true, false %>
         </div>
 
-        <div class="form-check form-switch">
+        <div class="form-check form-switch ps-3">
           <%= form.hidden_field :is_published, value: false %>
           <%= form.check_box :is_published, { class: "form-check-input", role: "switch", required: false }, true, false %>
         </div>

--- a/app/views/organizations/pets/_form.html.erb
+++ b/app/views/organizations/pets/_form.html.erb
@@ -86,6 +86,13 @@
         </div>
       </div>
 
+      <div class='form-group'>
+        <div class="form-check form-switch">
+          <%= form.hidden_field :is_published, value: false %>
+          <%= form.check_box :is_published, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" }, true, false %>
+        </div>
+      </div>
+
       <%= form.submit t('general.save'), class: 'btn btn-outline-dark mb-3 mt-4' %>
 
     <% end %>

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -82,7 +82,10 @@
                       <%= "#{pet.weight_from} - #{pet.weight_to} #{pet.weight_unit}" %>
                     </td>
                     <td>
-                      <span class="badge bg-info-soft"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
+                      <div class="d-inline-flex flex-column">
+                        <span class="badge bg-info-soft mb-3"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
+                        <span class="badge bg-info-soft"><%= pet.is_published ? "Published" : "Draft" %></span>
+                      </div>
                     </td>
                     <% if current_user.staff_account %>
                       <td>

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -110,6 +110,10 @@
                                 <i class="fe fe-pause dropdown-item-icon"></i>Pause applications
                               <% end %>
                             <% end %>
+                            <%= button_to pet, method: :put, class: 'dropdown-item', params: {pet: {is_published: !pet.is_published }} do %>
+                              <%= tag.i class: ["fe", "dropdown-item-icon", pet.is_published ? "fe-pause" : "fe-play"] %>
+                              <%= pet.is_published ? "Move to draft" : "Publish" %>
+                            <% end %>
                             <%= button_to pet, method: :delete, class: 'dropdown-item', data: { turbo_confirm: t('.are_you_sure_delete') } do %>
                               <i class="fe fe-trash dropdown-item-icon"></i>Delete
                             <% end %>

--- a/app/views/organizations/tasks/_overview.html.erb
+++ b/app/views/organizations/tasks/_overview.html.erb
@@ -78,7 +78,7 @@
               </div>
             </div>
           </li>
-          <li class="list-group-item px-0 pb-0">
+          <li class="list-group-item px-0">
             <div class="d-flex
                             justify-content-between
                             align-items-center">
@@ -98,7 +98,13 @@
               </div>
             </div>
           </li>
-
+          <li class="list-group-item px-0 pb-0 d-flex justify-content-between">
+            <span class="fw-bold">
+              <i class="fe fe-book me-2"></i>
+              Published
+            </span>
+            <%= tag.span "#{@pet.is_published}".titleize, class: "fw-semibold text-dark"%>
+          </li>
         </ul>
       </div>
     </div>

--- a/db/migrate/20231201204221_add_is_published_to_pets.rb
+++ b/db/migrate/20231201204221_add_is_published_to_pets.rb
@@ -1,0 +1,5 @@
+class AddIsPublishedToPets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :pets, :is_published, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_10_194816) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_01_204221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -193,6 +193,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_10_194816) do
     t.string "weight_unit", null: false
     t.integer "species", null: false
     t.integer "placement_type", null: false
+    t.boolean "is_published", default: true, null: false
     t.index ["organization_id"], name: "index_pets_on_organization_id"
   end
 
@@ -223,6 +224,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_10_194816) do
     t.index ["role_id"], name: "index_staff_accounts_roles_on_role_id"
     t.index ["staff_account_id", "role_id"], name: "index_staff_accounts_roles_on_staff_account_id_and_role_id"
     t.index ["staff_account_id"], name: "index_staff_accounts_roles_on_staff_account_id"
+  end
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.boolean "completed", default: false
+    t.bigint "pet_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["pet_id"], name: "index_tasks_on_pet_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -270,4 +281,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_10_194816) do
   add_foreign_key "pets", "organizations"
   add_foreign_key "staff_accounts", "organizations"
   add_foreign_key "staff_accounts", "users"
+  add_foreign_key "tasks", "pets"
 end


### PR DESCRIPTION
# 🔗 Issue
Closes #350 

# ✍️ Description

- [x] New column on pets table, called is_published, data type boolean, default: false 
- [x] Validation on model, required true
- [x] pet new/edit form has a toggle between draft and published next to, and similar to, the toggle for applications paused
- On the Pet's index page:
    - [x] the pet's index table clearly shows when a pet is published or draft
    - [x] staff can also toggle the pet between draft and publish via the pets index table, similar to the toggle for applications paused
- [x] pet show page summary table displays the value for is_published as Published:
- [ ] update tests for creating/editing a pet and add tests validating that draft pets do not show on the page of adoptable dogs that adopters and fosters see.
