### PR TITLE
Update styling to match theme on various pages

### DIFF
--- a/app/controllers/organizations/pets_controller.rb
+++ b/app/controllers/organizations/pets_controller.rb
@@ -1,7 +1,6 @@
 class Organizations::PetsController < Organizations::BaseController
   before_action :set_pet, only: [:show, :edit, :update, :destroy, :attach_images, :attach_files]
   before_action :verified_staff
-  before_action :set_nav_tabs, only: [:show]
 
   after_action :set_reason_paused_to_none, only: [:update]
   layout "dashboard"
@@ -110,12 +109,6 @@ class Organizations::PetsController < Organizations::BaseController
 
     @pet.pause_reason = 0
     @pet.save!
-  end
-
-  def set_nav_tabs
-    @nav_tabs = [
-      {name: "Summary", path: pet_path(@pet)}
-    ]
   end
 
   def determine_active_tab

--- a/app/views/components/dashboard/_page.html.erb
+++ b/app/views/components/dashboard/_page.html.erb
@@ -10,6 +10,11 @@
           <h2 class="section-heading text-capitalize">
             <%= partial.header_title %>
           </h2>
+          <% if partial.header_subtitle? %>
+            <p class="section-subheading text-muted mt-n2">
+              <%= partial.header_subtitle %>
+            </p>
+          <% end %>
           <%= breadcrumbs class: "breadcrumb", style: :ol, fragment_class: "breadcrumb-item" %>
         </div>
         <div class="d-flex">

--- a/app/views/components/dashboard/_page.html.erb
+++ b/app/views/components/dashboard/_page.html.erb
@@ -25,7 +25,7 @@
   </div>
 
   <div class="row">
-    <div class="col-12 mb-4 border-bottom">
+    <div class="col-12 border-bottom">
       <!-- Nav tabs -->
       <% if partial.nav_tabs? %>
         <ul class="nav nav-lb-tab mt-n3 gap-1">
@@ -35,5 +35,7 @@
     </div>
   </div>
 
-  <%= partial.content %>
+  <div class='mt-4'>
+    <%= partial.content %>
+  </div>
 </section>

--- a/app/views/components/pet_tabs/_tasks.html.erb
+++ b/app/views/components/pet_tabs/_tasks.html.erb
@@ -19,7 +19,7 @@
             <%= turbo_frame_tag dom_id(task) do %>
               <li class="list-group-item px-0">
                 <div class="d-flex justify-content-between
-                            align-items-center">
+                             align-items-center">
                   <div style="padding: 10px;">
                     <strong class="d-block mb-1" ><%= task.name %></strong>
                     <p><%= task.description %></p>

--- a/app/views/organizations/organization_profiles/_form.html.erb
+++ b/app/views/organizations/organization_profiles/_form.html.erb
@@ -92,6 +92,7 @@
     <div class="row mt-3">
       <div class="col-lg-12">
         <%= form.submit 'Save profile', class: 'btn btn-primary' %>
+        <%= link_to 'Cancel', :back, class: 'btn btn-outline-secondary' %>
       </div>
     </div>
   </div> <!-- End of Card Body -->

--- a/app/views/organizations/organization_profiles/_form.html.erb
+++ b/app/views/organizations/organization_profiles/_form.html.erb
@@ -92,7 +92,7 @@
     <div class="row mt-3">
       <div class="col-lg-12">
         <%= form.submit 'Save profile', class: 'btn btn-primary' %>
-        <%= link_to 'Cancel', :back, class: 'btn btn-outline-secondary' %>
+        <%= link_to t('general.cancel'), :back, class: 'btn btn-outline-secondary' %>
       </div>
     </div>
   </div> <!-- End of Card Body -->

--- a/app/views/organizations/organization_profiles/edit.html.erb
+++ b/app/views/organizations/organization_profiles/edit.html.erb
@@ -8,7 +8,6 @@
       <div>
         <div>
           <%= render "form", profile: @organization_profile %>
-          <%= link_to t('general.back'), dashboard_index_path %>
         </div>
       </div>
     </section>

--- a/app/views/organizations/organization_profiles/edit.html.erb
+++ b/app/views/organizations/organization_profiles/edit.html.erb
@@ -1,4 +1,4 @@
-<% breadcrumb :organization_profile, @pet %>
+<% breadcrumb :organization_profile %>
 
 <%= render "components/dashboard/page" do |p| %>
   <% p.header_title "Profile Details" %>

--- a/app/views/organizations/organization_profiles/edit.html.erb
+++ b/app/views/organizations/organization_profiles/edit.html.erb
@@ -5,7 +5,7 @@
   <% p.header_subtitle "Manage your profile details" %>
   <% p.content do %>
     <section id="account_select">
-      <div class="container">
+      <div>
         <div>
           <%= render "form", profile: @organization_profile %>
           <%= link_to t('general.back'), dashboard_index_path %>

--- a/app/views/organizations/organization_profiles/edit.html.erb
+++ b/app/views/organizations/organization_profiles/edit.html.erb
@@ -1,24 +1,16 @@
-<!--page heading-->
-<header class="pt-5 pb-5">
-  <div class="container">
-    <div class="text-center">
-      <h1 class="section-heading text-uppercase underline">
-        <%= @organization_profile.name %> <%= t('.profile_details') %>
-      </h1>
-      <p class="mb-0">
-        <%= t('.manage_your_own_account_settings') %>
-      </p>
-    </div>
-  </div> <!--container-->
-</header>
+<% breadcrumb :organization_profile, @pet %>
 
-<!--rendering _form.html.erb--> 
-<section class="pb-5" id="account_select">
-  <div class="container">
-    <div class="col-md-8 mx-auto">
-        <%= render "form", profile: @organization_profile %>
-        <%= link_to t('general.back'), dashboard_index_path %>
-    </div>
-  </div> <!--container-->
-</section>
-
+<%= render "components/dashboard/page" do |p| %>
+  <% p.header_title "Profile Details" %>
+  <% p.header_subtitle "Manage your profile details" %>
+  <% p.content do %>
+    <section id="account_select">
+      <div class="container">
+        <div>
+          <%= render "form", profile: @organization_profile %>
+          <%= link_to t('general.back'), dashboard_index_path %>
+        </div>
+      </div>
+    </section>
+  <% end %>
+<% end %>

--- a/app/views/organizations/pets/_form.html.erb
+++ b/app/views/organizations/pets/_form.html.erb
@@ -86,9 +86,8 @@
         </div>
       </div>
 
-      <%= form.submit t('general.save'), class: 'btn btn-outline-dark mb-3 mt-4' %>
-
+      <%= form.submit t('general.save'), class: 'btn btn-primary' %>
+      <%= link_to t('general.cancel'), pets_path, class: 'btn btn-secondary' %>
     <% end %>
-
   </div>
 </div> <!--row-->

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -8,29 +8,33 @@
 
   <% p.content do %>
     <!--filter section-->
-    <div class="p-4 border rounded-5 mb-5 bg-white">
+    <div>
       <div>
         <%= search_form_for @q do |f| %>
-          <div class="row">
-            <div class="form-group mb-3 col-md-6">
-              <%= f.label :name_i_cont, "Name" %>
-              <%= f.text_field :name_i_cont, class: "form-control", placeholder: "Enter a few characters" %>
+          <div class='d-flex justify-content-between align-items-center flex-wrap mb-3'>
+            <div class="d-flex gap-3 flex-wrap mb-3">
+              <div class="form-group">
+                <%= f.label :name_i_cont, "Name" %>
+                <%= f.text_field :name_i_cont, class: "form-control", placeholder: "Enter a few characters" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :sex_eq, "Sex" %>
+                <%= f.select :sex_eq, ["Male", "Female"], {include_blank: 'All'}, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :species_eq, "Species" %>
+                <%= f.select :species_eq, Pet.species, {include_blank: 'All'}, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :ransack_adopted, "Status" %>
+                <%= f.select :ransack_adopted, [['Adopted', true], ['Unadopted', false]], {include_blank: 'All'}, class: "form-select" %>
+              </div>
             </div>
-            <div class="mb-3 form-group col-md-2">
-              <%= f.label :sex_eq, "Sex" %>
-              <%= f.select :sex_eq, ["Male", "Female"], {include_blank: 'All'}, class: "form-select" %>
-            </div>
-            <div class="mb-3 form-group col-md-2">
-              <%= f.label :species_eq, "Species" %>
-              <%= f.select :species_eq, Pet.species, {include_blank: 'All'}, class: "form-select" %>
-            </div>
-            <div class="mb-3 form-group col-md-2">
-              <%= f.label :ransack_adopted, "Status" %>
-              <%= f.select :ransack_adopted, [['Adopted', true], ['Unadopted', false]], {include_blank: 'All'}, class: "form-select" %>
+            <div class='d-flex flex-column w-100 w-md-auto flex-md-row'>
+              <%= f.submit class: "btn btn-primary" %>
+              <%= link_to "Clear filters", pets_path, class: "btn btn-default"%>
             </div>
           </div>
-          <%= f.submit class: "btn btn-primary" %>
-          <%= link_to "Clear filters", pets_path, class: "btn btn-default"%>
         <% end %>
       </div>
     </div>

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -7,120 +7,118 @@
   <% end %>
 
   <% p.content do %>
-    <section class="container-fluid p-4">
-      <!--filter section-->
-      <div class="row p-4 border rounded-5 mb-5 bg-white">
-        <div class="col-xl-8">
-          <%= search_form_for @q do |f| %>
-            <div class="row">
-              <div class="form-group mb-3 col-md-6">
-                <%= f.label :name_i_cont, "Name" %>
-                <%= f.text_field :name_i_cont, class: "form-control", placeholder: "Enter a few characters" %>
-              </div>
-              <div class="mb-3 form-group col-md-2">
-                <%= f.label :sex_eq, "Sex" %>
-                <%= f.select :sex_eq, ["Male", "Female"], {include_blank: 'All'}, class: "form-select" %>
-              </div>
-              <div class="mb-3 form-group col-md-2">
-                <%= f.label :species_eq, "Species" %>
-                <%= f.select :species_eq, Pet.species, {include_blank: 'All'}, class: "form-select" %>
-              </div>
-              <div class="mb-3 form-group col-md-2">
-                <%= f.label :ransack_adopted, "Status" %>
-                <%= f.select :ransack_adopted, [['Adopted', true], ['Unadopted', false]], {include_blank: 'All'}, class: "form-select" %>
-              </div>
+    <!--filter section-->
+    <div class="p-4 border rounded-5 mb-5 bg-white">
+      <div>
+        <%= search_form_for @q do |f| %>
+          <div class="row">
+            <div class="form-group mb-3 col-md-6">
+              <%= f.label :name_i_cont, "Name" %>
+              <%= f.text_field :name_i_cont, class: "form-control", placeholder: "Enter a few characters" %>
             </div>
-            <%= f.submit class: "btn btn-primary" %>
-            <%= link_to "Clear filters", pets_path, class: "btn btn-default"%>
-          <% end %>
-        </div>
+            <div class="mb-3 form-group col-md-2">
+              <%= f.label :sex_eq, "Sex" %>
+              <%= f.select :sex_eq, ["Male", "Female"], {include_blank: 'All'}, class: "form-select" %>
+            </div>
+            <div class="mb-3 form-group col-md-2">
+              <%= f.label :species_eq, "Species" %>
+              <%= f.select :species_eq, Pet.species, {include_blank: 'All'}, class: "form-select" %>
+            </div>
+            <div class="mb-3 form-group col-md-2">
+              <%= f.label :ransack_adopted, "Status" %>
+              <%= f.select :ransack_adopted, [['Adopted', true], ['Unadopted', false]], {include_blank: 'All'}, class: "form-select" %>
+            </div>
+          </div>
+          <%= f.submit class: "btn btn-primary" %>
+          <%= link_to "Clear filters", pets_path, class: "btn btn-default"%>
+        <% end %>
       </div>
+    </div>
 
-      <!-- row -->
-      <div class="row justify-content-md-between mb-4 mb-xl-0 gx-3">
-        <!-- card -->
-        <div class="card">
-          <!-- table -->
-          <div class="table-responsive overflow-y-hidden">
-            <table class="table mb-0 text-nowrap table-hover table-centered">
-              <thead>
+    <!-- row -->
+    <div class="justify-content-md-between mb-4 mb-xl-0 gx-3">
+      <!-- card -->
+      <div class="card">
+        <!-- table -->
+        <div class="table-responsive overflow-y-hidden">
+          <table class="table mb-0 text-nowrap table-hover table-centered">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Sex</th>
+                <th scope="col">Breed</th>
+                <th scope="col">Weight</th>
+                <th scope="col">Status</th>
+                <th scope="col"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @pets.each do |pet| %>
                 <tr>
-                  <th scope="col">Name</th>
-                  <th scope="col">Sex</th>
-                  <th scope="col">Breed</th>
-                  <th scope="col">Weight</th>
-                  <th scope="col">Status</th>
-                  <th scope="col"></th>
-                </tr>
-              </thead>
-              <tbody>
-                <% @pets.each do |pet| %>
-                  <tr>
+                  <td>
+                    <div class="d-flex align-items-center">
+                      <div class="icon-shape icon-lg rounded-3 border">
+                        <% if pet.images.attached? %>
+                          <%= image_tag pet.images.first, class: 'card-img' %>
+                        <% else %>
+                          <%= image_tag('coming_soon.jpg', class: 'card-img') %>
+                        <% end %>
+                      </div>
+                      <div class="ms-3">
+                        <h4 class="mb-0">
+                          <%= link_to pet.name, pet_path(pet), class: 'text-inherit' %>
+                        </h4>
+                      </div>
+                    </div>
+                  </td>
+                  <td>
+                    <%= pet.sex %>
+                  </td>
+                  <td>
+                    <%= pet.breed %>
+                  </td>
+                  <td>
+                    <%= "#{pet.weight_from} - #{pet.weight_to} #{pet.weight_unit}" %>
+                  </td>
+                  <td>
+                    <span class="badge bg-info-soft"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
+                  </td>
+                  <% if current_user.staff_account %>
                     <td>
-                      <div class="d-flex align-items-center">
-                        <div class="icon-shape icon-lg rounded-3 border">
-                          <% if pet.images.attached? %>
-                            <%= image_tag pet.images.first, class: 'card-img' %>
-                          <% else %>
-                            <%= image_tag('coming_soon.jpg', class: 'card-img') %>
+                      <div class="dropdown dropstart">
+                        <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" id="Dropdown1" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                          <i class="fe fe-more-vertical"></i>
+                        </a>
+                        <div class="dropdown-menu" aria-labelledby="Dropdown1">
+                          <span class="dropdown-header">Settings</span>
+                          <%= link_to pet_path(pet), class: 'dropdown-item' do %>
+                            <i class="fe fe-edit dropdown-item-icon"></i>Edit Details
                           <% end %>
-                        </div>
-                        <div class="ms-3">
-                          <h4 class="mb-0">
-                            <%= link_to pet.name, pet_path(pet), class: 'text-inherit' %>
-                          </h4>
+                          <%= link_to pet_path(pet), class: 'dropdown-item' do %>
+                            <i class="fe fe-link dropdown-item-icon"></i>Copy link
+                          <% end %>
+                          <% if pet.application_paused %>
+                            <%= button_to pet, method: :put, class: 'dropdown-item', params: {pet: {application_paused: false }} do %>
+                              <i class="fe fe-play dropdown-item-icon"></i>Resume applications
+                            <% end %>
+                          <% else %>
+                            <%= button_to pet, method: :put, class: 'dropdown-item', params: {pet: {application_paused: true}} do %>
+                              <i class="fe fe-pause dropdown-item-icon"></i>Pause applications
+                            <% end %>
+                          <% end %>
+                          <%= button_to pet, method: :delete, class: 'dropdown-item', data: { turbo_confirm: t('.are_you_sure_delete') } do %>
+                            <i class="fe fe-trash dropdown-item-icon"></i>Delete
+                          <% end %>
                         </div>
                       </div>
                     </td>
-                    <td>
-                      <%= pet.sex %>
-                    </td>
-                    <td>
-                      <%= pet.breed %>
-                    </td>
-                    <td>
-                      <%= "#{pet.weight_from} - #{pet.weight_to} #{pet.weight_unit}" %>
-                    </td>
-                    <td>
-                      <span class="badge bg-info-soft"><%= pet.application_paused == false ? t('.application.active') : t('.application.paused') %></span>
-                    </td>
-                    <% if current_user.staff_account %>
-                      <td>
-                        <div class="dropdown dropstart">
-                          <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" id="Dropdown1" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            <i class="fe fe-more-vertical"></i>
-                          </a>
-                          <div class="dropdown-menu" aria-labelledby="Dropdown1">
-                            <span class="dropdown-header">Settings</span>
-                            <%= link_to pet_path(pet), class: 'dropdown-item' do %>
-                              <i class="fe fe-edit dropdown-item-icon"></i>Edit Details
-                            <% end %>
-                            <%= link_to pet_path(pet), class: 'dropdown-item' do %>
-                              <i class="fe fe-link dropdown-item-icon"></i>Copy link
-                            <% end %>
-                            <% if pet.application_paused %>
-                              <%= button_to pet, method: :put, class: 'dropdown-item', params: {pet: {application_paused: false }} do %>
-                                <i class="fe fe-play dropdown-item-icon"></i>Resume applications
-                              <% end %>
-                            <% else %>
-                              <%= button_to pet, method: :put, class: 'dropdown-item', params: {pet: {application_paused: true}} do %>
-                                <i class="fe fe-pause dropdown-item-icon"></i>Pause applications
-                              <% end %>
-                            <% end %>
-                            <%= button_to pet, method: :delete, class: 'dropdown-item', data: { turbo_confirm: t('.are_you_sure_delete') } do %>
-                              <i class="fe fe-trash dropdown-item-icon"></i>Delete
-                            <% end %>
-                          </div>
-                        </div>
-                      </td>
-                    <% end %>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          </div>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
         </div>
       </div>
-    </section>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/organizations/pets/index.html.erb
+++ b/app/views/organizations/pets/index.html.erb
@@ -30,7 +30,7 @@
                 <%= f.select :ransack_adopted, [['Adopted', true], ['Unadopted', false]], {include_blank: 'All'}, class: "form-select" %>
               </div>
             </div>
-            <div class='d-flex flex-column w-100 w-md-auto flex-md-row'>
+            <div class='d-flex flex-column w-100 w-md-auto flex-md-row gap-2'>
               <%= f.submit class: "btn btn-primary" %>
               <%= link_to "Clear filters", pets_path, class: "btn btn-default"%>
             </div>

--- a/app/views/organizations/pets/show.html.erb
+++ b/app/views/organizations/pets/show.html.erb
@@ -1,44 +1,38 @@
 <% breadcrumb :dashboard_pet, @pet %>
 
-<div class="row">
-  <!-- from 265 -->
-  <div class="col-12 mb-4">
-    <!-- nav -->
-    <ul class="nav nav-lb-tab">
-      <li class="nav-item ms-0 me-3">
-        <%= link_to 'Overview', pet_path(@pet, active_tab: 'overview'), class: 'nav-link' + (@active_tab == 'overview' ? ' active' : '') %>
-      </li>
-      <li class="nav-item mx-3">
-        <%= link_to 'Tasks', pet_path(@pet, active_tab: 'tasks'), class: 'nav-link' + (@active_tab == 'tasks' ? ' active' : '') %>
-      </li>
-      <li class="nav-item mx-3">
-        <%= link_to 'Applications', pet_path(@pet, active_tab: 'applications'), class: 'nav-link' + (@active_tab == 'applications' ? ' active' : '') %>
-      </li>
-      <li class="nav-item mx-3">
-        <%= link_to 'Photos', pet_path(@pet, active_tab: 'photos'), class: 'nav-link' + (@active_tab == 'photos' ? ' active' : '') %>
-      </li>
-      <li class="nav-item mx-3">
-        <%= link_to 'Files', pet_path(@pet, active_tab: 'files'), class: 'nav-link' + (@active_tab == 'files' ? ' active' : '') %>
-      </li>
-    </ul>
-  </div>
+<%= render "components/dashboard/page" do |p| %>
+  <% p.header_title @pet.name %>
+  <% p.nav_tabs do %>
+    <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'overview'), text: "Overview", options: { active: :exact } %>
+    <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'tasks'), text: "Tasks", options: { active: :exact } %>
+    <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'applications'), text: "Applications", options: { active: :exact } %>
+    <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'photos'), text: "Photos", options: { active: :exact } %>
+    <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'files'), text: "Files", options: { active: :exact } %>
+  <% end %>
 
-  <div class="col-md-12 col-xl-8 col-12">
-    <% if @active_tab == 'tasks' %>
-      <%= render partial: "organizations/tasks/tasks", locals: { pet: @pet } %>
-    <% else %>
-      <%= render partial: "components/pet_tabs/#{@active_tab}", locals: { pet: @pet } %>
-    <% end %>
-  </div> 
+  <% p.content do %>
 
-  <div class="col-md-12 col-xl-4 col-12">
-
-    <div class="mb-4">
-      <div>
-        <% if @pet.images.attached? %>
-          <%= image_tag @pet.images.first, class: 'rounded card-img-top' %>
+    <div class="row">
+      <div class="col-md-12 col-xl-8 col-12">
+        <% if @active_tab == 'tasks' %>
+          <%= render partial: "organizations/tasks/tasks", locals: { pet: @pet } %>
         <% else %>
-          <%= image_tag('coming_soon.jpg', class: 'rounded card-img-top') %>
+          <%= render partial: "components/pet_tabs/#{@active_tab}", locals: { pet: @pet } %>
         <% end %>
+      </div> 
+
+      <div class="col-md-12 col-xl-4 col-12">
+
+        <div class="mb-4">
+          <div>
+            <% if @pet.images.attached? %>
+              <%= image_tag @pet.images.first, class: 'rounded card-img-top' %>
+            <% else %>
+              <%= image_tag('coming_soon.jpg', class: 'rounded card-img-top') %>
+            <% end %>
+          </div>
+        </div>  
       </div>
-    </div>  
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/organizations/pets/show.html.erb
+++ b/app/views/organizations/pets/show.html.erb
@@ -3,7 +3,7 @@
 <%= render "components/dashboard/page" do |p| %>
   <% p.header_title @pet.name %>
   <% p.nav_tabs do %>
-    <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'overview'), text: "Overview", options: { active: :exact } %>
+    <%= render "components/dashboard/nav_tab", url: pet_path(@pet), text: "Overview", options: { active: :exact } %>
     <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'tasks'), text: "Tasks", options: { active: :exact } %>
     <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'applications'), text: "Applications", options: { active: :exact } %>
     <%= render "components/dashboard/nav_tab", url: pet_path(@pet, active_tab: 'photos'), text: "Photos", options: { active: :exact } %>
@@ -11,14 +11,9 @@
   <% end %>
 
   <% p.content do %>
-
     <div class="row">
       <div class="col-md-12 col-xl-8 col-12">
-        <% if @active_tab == 'tasks' %>
-          <%= render partial: "organizations/tasks/tasks", locals: { pet: @pet } %>
-        <% else %>
-          <%= render partial: "components/pet_tabs/#{@active_tab}", locals: { pet: @pet } %>
-        <% end %>
+        <%= render partial: "components/pet_tabs/#{@active_tab}", locals: { pet: @pet } %>
       </div> 
 
       <div class="col-md-12 col-xl-4 col-12">

--- a/app/views/organizations/staff/index.html.erb
+++ b/app/views/organizations/staff/index.html.erb
@@ -30,11 +30,7 @@
         <div class="tab-content">
           <!-- Tab Pane -->
           <div class="tab-pane fade" id="tabPaneGrid" role="tabpanel" aria-labelledby="tabPaneGrid">
-            <div class="mb-4">
-              <input type="search" class="form-control" placeholder="Search Staff">
-            </div>
-            <div class="row">
-
+            <div class='d-flex gap-3'>
               <% @staff_accounts.each do |staff| %>
                 <div class="col-xl-3 col-lg-6 col-md-6 col-12">
                   <!-- Card -->
@@ -68,86 +64,83 @@
               <% end %>
             </div>
           </div>
-          <!-- Tab Pane -->
-          <div class="tab-pane fade active show" id="tabPaneList" role="tabpanel" aria-labelledby="tabPaneList">
-            <!-- Card -->
-            <div class="card">
-              <!-- Card Header -->
-              <div class="card-header">
-                <input type="search" class="form-control" placeholder="Search Staff">
-              </div>
-              <!-- Table -->
-              <div class="table-responsive">
-                <table class="table mb-0 text-nowrap table-hover table-centered">
-                  <thead class="table-light">
+        </div>
+        <!-- Tab Pane -->
+        <div class="tab-pane fade active show" id="tabPaneList" role="tabpanel" aria-labelledby="tabPaneList">
+          <!-- Card -->
+          <div class="card">
+            <!-- Table -->
+            <div class="table-responsive">
+              <table class="table mb-0 text-nowrap table-hover table-centered">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Role</th>
+                    <th scope="col">Joined At</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Action</th>
+
+                  </tr>
+                </thead>
+                <tbody>
+
+                  <% @staff_accounts.each do |staff| %>
                     <tr>
-                      <th scope="col">Name</th>
-                      <th scope="col">Role</th>
-                      <th scope="col">Joined At</th>
-                      <th scope="col">Status</th>
-                      <th scope="col">Action</th>
-
-                    </tr>
-                  </thead>
-                  <tbody>
-
-                    <% @staff_accounts.each do |staff| %>
-                      <tr>
-                        <td>
-                          <div class="d-flex align-items-center">
-                            <div class="position-relative">
-                              <%= image_tag "danielle_3.jpg", alt: "", class: "rounded-circle avatar-md me-2" %>
-                              <a href="#" class="position-absolute mt-5 ms-n4">
-                                <span class="status bg-success"></span>
-                              </a>
-                            </div>
-                            <h5 class="mb-0"><%= "#{staff.user.first_name} #{staff.user.last_name}" %></h5>
+                      <td>
+                        <div class="d-flex align-items-center">
+                          <div class="position-relative">
+                            <%= image_tag "danielle_3.jpg", alt: "", class: "rounded-circle avatar-md me-2" %>
+                            <a href="#" class="position-absolute mt-5 ms-n4">
+                              <span class="status bg-success"></span>
+                            </a>
                           </div>
-                        </td>
-                        <td>
-                          <%= staff.roles.pluck(:name).join(", ") %>
-                        </td>
-                        <td>
-                          <%= staff.created_at.strftime("%d %B, %Y") %>
-                        </td>
-                        <td>
-                          <%= t("staff_accounts.status.#{staff.status}") %>
-                        </td>
+                          <h5 class="mb-0"><%= "#{staff.user.first_name} #{staff.user.last_name}" %></h5>
+                        </div>
+                      </td>
+                      <td>
+                        <%= staff.roles.pluck(:name).join(", ") %>
+                      </td>
+                      <td>
+                        <%= staff.created_at.strftime("%d %B, %Y") %>
+                      </td>
+                      <td>
+                        <%= t("staff_accounts.status.#{staff.status}") %>
+                      </td>
 
-                        <td>
-                          <div class="hstack gap-4">
-                            <a href="#" class="fe fe-mail text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Message" data-bs-original-title="Message"></a>
-                            <a href="#" class="text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Delete" data-bs-original-title="Delete"><i class="fe fe-trash"></i></a>
-                            <span class="dropdown dropstart">
-                              <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
-                                <i class="fe fe-more-vertical"></i>
-                              </a>
-                              <span class="dropdown-menu">
-                                <span class="dropdown-header">Settings</span>
-                                <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i> Edit</a>
-                                <% if staff.deactivated_at %>
-                                  <%= button_to staff_activate_path(staff), class: "dropdown-item" do %>
-                                    <i class="fe fe-unlock dropdown-item-icon"></i> Activate
-                                  <% end %>
-                                <% else %>
-                                  <%= button_to staff_deactivate_path(staff), class: "dropdown-item" do %>
-                                    <i class="fe fe-lock  dropdown-item-icon"></i> Deactivate
-                                  <% end %>
+                      <td>
+                        <div class="hstack gap-4">
+                          <a href="#" class="fe fe-mail text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Message" data-bs-original-title="Message"></a>
+                          <a href="#" class="text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Delete" data-bs-original-title="Delete"><i class="fe fe-trash"></i></a>
+                          <span class="dropdown dropstart">
+                            <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
+                              <i class="fe fe-more-vertical"></i>
+                            </a>
+                            <span class="dropdown-menu">
+                              <span class="dropdown-header">Settings</span>
+                              <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i> Edit</a>
+                              <% if staff.deactivated_at %>
+                                <%= button_to staff_activate_path(staff), class: "dropdown-item" do %>
+                                  <i class="fe fe-unlock dropdown-item-icon"></i> Activate
                                 <% end %>
-                              </span>
+                              <% else %>
+                                <%= button_to staff_deactivate_path(staff), class: "dropdown-item" do %>
+                                  <i class="fe fe-lock  dropdown-item-icon"></i> Deactivate
+                                <% end %>
+                              <% end %>
                             </span>
-                          </div>
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
+                          </span>
+                        </div>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
 
-              </div>
             </div>
           </div>
         </div>
       </div>
+    </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/organizations/staff/index.html.erb
+++ b/app/views/organizations/staff/index.html.erb
@@ -1,151 +1,152 @@
-<!--page heading-->
-<%= provide(:header_title, "Staff") %>
+<% breadcrumb :staff_index %>
 
-<!--create staff button-->
-<%= content_for :button do %>
-  <%= link_to "Invite Staff", new_user_invitation_path, class: "btn btn-primary" %><br>
-<% end %>
+<%= render "components/dashboard/page" do |p| %>
+  <% p.header_title "Staff" %>
+  <% p.actions do %>
+    <%= link_to "Invite Staff", new_user_invitation_path, class: "btn btn-primary" %><br>
+  <% end %>
 
-<section class="container-fluid p-4">
-  <div class="row">
-    <div class="col-lg-12 col-md-12 col-12">
-      <!-- Page Header -->
-      <div class="border-bottom pb-3 mb-3 d-flex justify-content-between align-items-center">
-        <div class="nav btn-group" role="tablist">
-          <button class="btn btn-outline-secondary" data-bs-toggle="tab" data-bs-target="#tabPaneGrid" role="tab" aria-controls="tabPaneGrid" aria-selected="false" tabindex="-1">
-            <span class="fe fe-grid"></span>
-          </button>
-          <button class="btn btn-outline-secondary active" data-bs-toggle="tab" data-bs-target="#tabPaneList" role="tab" aria-controls="tabPaneList" aria-selected="true">
-            <span class="fe fe-list"></span>
-          </button>
+  <% p.content do %>
+    <div class="row">
+      <div class="col-lg-12 col-md-12 col-12">
+        <!-- Page Header -->
+        <div class="border-bottom pb-3 mb-3 d-flex justify-content-between align-items-center">
+          <div class="nav btn-group" role="tablist">
+            <button class="btn btn-outline-secondary" data-bs-toggle="tab" data-bs-target="#tabPaneGrid" role="tab" aria-controls="tabPaneGrid" aria-selected="false" tabindex="-1">
+              <span class="fe fe-grid"></span>
+            </button>
+            <button class="btn btn-outline-secondary active" data-bs-toggle="tab" data-bs-target="#tabPaneList" role="tab" aria-controls="tabPaneList" aria-selected="true">
+              <span class="fe fe-list"></span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="row">
-    <div class="col-lg-12 col-md-12 col-12">
-      <!-- Tab -->
-      <div class="tab-content">
-        <!-- Tab Pane -->
-        <div class="tab-pane fade" id="tabPaneGrid" role="tabpanel" aria-labelledby="tabPaneGrid">
-          <div class="mb-4">
-            <input type="search" class="form-control" placeholder="Search Staff">
-          </div>
-          <div class="row">
-
-            <% @staff_accounts.each do |staff| %>
-              <div class="col-xl-3 col-lg-6 col-md-6 col-12">
-                <!-- Card -->
-                <div class="card mb-4">
-                  <!-- Card body -->
-                  <div class="card-body">
-                    <div class="text-center">
-                      <div class="position-relative">
-                        <%= image_tag "danielle_3.jpg", alt: "", class: "rounded-circle avatar-xl mb-3" %>
-                        <a href="#" class="position-absolute mt-10 ms-n5">
-                          <span class="status bg-success"></span>
-                        </a>
-                      </div>
-                      <h4 class="mb-0"><%= "#{staff.user.first_name} #{staff.user.last_name}" %></h4>
-                    </div>
-                    <div class="d-flex justify-content-between border-bottom py-2 mt-4">
-                      <span>Role</span>
-                      <span class="text-dark"><%= staff.roles.pluck(:name).join(", ") %></span>
-                    </div>
-                    <div class="d-flex justify-content-between border-bottom py-2">
-                      <span>Joined</span>
-                      <span><%= staff.created_at.strftime("%d %B, %Y") %></span>
-                    </div>
-                    <div class="d-flex justify-content-between pt-2">
-                      <span>Status</span>
-                      <span class="text-dark"><%= t("staff_accounts.status.#{staff.status}") %></span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            <% end %>
-          </div>
-        </div>
-        <!-- Tab Pane -->
-        <div class="tab-pane fade active show" id="tabPaneList" role="tabpanel" aria-labelledby="tabPaneList">
-          <!-- Card -->
-          <div class="card">
-            <!-- Card Header -->
-            <div class="card-header">
+    <div class="row">
+      <div class="col-lg-12 col-md-12 col-12">
+        <!-- Tab -->
+        <div class="tab-content">
+          <!-- Tab Pane -->
+          <div class="tab-pane fade" id="tabPaneGrid" role="tabpanel" aria-labelledby="tabPaneGrid">
+            <div class="mb-4">
               <input type="search" class="form-control" placeholder="Search Staff">
             </div>
-            <!-- Table -->
-            <div class="table-responsive">
-              <table class="table mb-0 text-nowrap table-hover table-centered">
-                <thead class="table-light">
-                <tr>
-                  <th scope="col">Name</th>
-                  <th scope="col">Role</th>
-                  <th scope="col">Joined At</th>
-                  <th scope="col">Status</th>
-                  <th scope="col">Action</th>
+            <div class="row">
 
-                </tr>
-                </thead>
-                <tbody>
-
-                <% @staff_accounts.each do |staff| %>
-                  <tr>
-                    <td>
-                      <div class="d-flex align-items-center">
+              <% @staff_accounts.each do |staff| %>
+                <div class="col-xl-3 col-lg-6 col-md-6 col-12">
+                  <!-- Card -->
+                  <div class="card mb-4">
+                    <!-- Card body -->
+                    <div class="card-body">
+                      <div class="text-center">
                         <div class="position-relative">
-                          <%= image_tag "danielle_3.jpg", alt: "", class: "rounded-circle avatar-md me-2" %>
-                          <a href="#" class="position-absolute mt-5 ms-n4">
+                          <%= image_tag "danielle_3.jpg", alt: "", class: "rounded-circle avatar-xl mb-3" %>
+                          <a href="#" class="position-absolute mt-10 ms-n5">
                             <span class="status bg-success"></span>
                           </a>
                         </div>
-                        <h5 class="mb-0"><%= "#{staff.user.first_name} #{staff.user.last_name}" %></h5>
+                        <h4 class="mb-0"><%= "#{staff.user.first_name} #{staff.user.last_name}" %></h4>
                       </div>
-                    </td>
-                    <td>
-                      <%= staff.roles.pluck(:name).join(", ") %>
-                    </td>
-                    <td>
-                      <%= staff.created_at.strftime("%d %B, %Y") %>
-                    </td>
-                    <td>
-                      <%= t("staff_accounts.status.#{staff.status}") %>
-                    </td>
+                      <div class="d-flex justify-content-between border-bottom py-2 mt-4">
+                        <span>Role</span>
+                        <span class="text-dark"><%= staff.roles.pluck(:name).join(", ") %></span>
+                      </div>
+                      <div class="d-flex justify-content-between border-bottom py-2">
+                        <span>Joined</span>
+                        <span><%= staff.created_at.strftime("%d %B, %Y") %></span>
+                      </div>
+                      <div class="d-flex justify-content-between pt-2">
+                        <span>Status</span>
+                        <span class="text-dark"><%= t("staff_accounts.status.#{staff.status}") %></span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <!-- Tab Pane -->
+          <div class="tab-pane fade active show" id="tabPaneList" role="tabpanel" aria-labelledby="tabPaneList">
+            <!-- Card -->
+            <div class="card">
+              <!-- Card Header -->
+              <div class="card-header">
+                <input type="search" class="form-control" placeholder="Search Staff">
+              </div>
+              <!-- Table -->
+              <div class="table-responsive">
+                <table class="table mb-0 text-nowrap table-hover table-centered">
+                  <thead class="table-light">
+                    <tr>
+                      <th scope="col">Name</th>
+                      <th scope="col">Role</th>
+                      <th scope="col">Joined At</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">Action</th>
 
-                    <td>
-                      <div class="hstack gap-4">
-                        <a href="#" class="fe fe-mail text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Message" data-bs-original-title="Message"></a>
-                        <a href="#" class="text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Delete" data-bs-original-title="Delete"><i class="fe fe-trash"></i></a>
-                        <span class="dropdown dropstart">
-                          <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
-                            <i class="fe fe-more-vertical"></i>
-                          </a>
-                          <span class="dropdown-menu">
-                            <span class="dropdown-header">Settings</span>
-                              <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i> Edit</a>
-                              <% if staff.deactivated_at %>
-                                <%= button_to staff_activate_path(staff), class: "dropdown-item" do %>
-                                  <i class="fe fe-unlock dropdown-item-icon"></i> Activate
+                    </tr>
+                  </thead>
+                  <tbody>
+
+                    <% @staff_accounts.each do |staff| %>
+                      <tr>
+                        <td>
+                          <div class="d-flex align-items-center">
+                            <div class="position-relative">
+                              <%= image_tag "danielle_3.jpg", alt: "", class: "rounded-circle avatar-md me-2" %>
+                              <a href="#" class="position-absolute mt-5 ms-n4">
+                                <span class="status bg-success"></span>
+                              </a>
+                            </div>
+                            <h5 class="mb-0"><%= "#{staff.user.first_name} #{staff.user.last_name}" %></h5>
+                          </div>
+                        </td>
+                        <td>
+                          <%= staff.roles.pluck(:name).join(", ") %>
+                        </td>
+                        <td>
+                          <%= staff.created_at.strftime("%d %B, %Y") %>
+                        </td>
+                        <td>
+                          <%= t("staff_accounts.status.#{staff.status}") %>
+                        </td>
+
+                        <td>
+                          <div class="hstack gap-4">
+                            <a href="#" class="fe fe-mail text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Message" data-bs-original-title="Message"></a>
+                            <a href="#" class="text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Delete" data-bs-original-title="Delete"><i class="fe fe-trash"></i></a>
+                            <span class="dropdown dropstart">
+                              <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
+                                <i class="fe fe-more-vertical"></i>
+                              </a>
+                              <span class="dropdown-menu">
+                                <span class="dropdown-header">Settings</span>
+                                <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i> Edit</a>
+                                <% if staff.deactivated_at %>
+                                  <%= button_to staff_activate_path(staff), class: "dropdown-item" do %>
+                                    <i class="fe fe-unlock dropdown-item-icon"></i> Activate
+                                  <% end %>
+                                <% else %>
+                                  <%= button_to staff_deactivate_path(staff), class: "dropdown-item" do %>
+                                    <i class="fe fe-lock  dropdown-item-icon"></i> Deactivate
+                                  <% end %>
                                 <% end %>
-                              <% else %>
-                                <%= button_to staff_deactivate_path(staff), class: "dropdown-item" do %>
-                                  <i class="fe fe-lock  dropdown-item-icon"></i> Deactivate
-                                <% end %>
-                              <% end %>
+                              </span>
                             </span>
-                          </span>
-                      </div>
-                    </td>
-                  </tr>
-                <% end %>
-                </tbody>
-              </table>
+                          </div>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
 
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  <% end %>
+<% end %>

--- a/app/views/organizations/staff/index.html.erb
+++ b/app/views/organizations/staff/index.html.erb
@@ -3,26 +3,27 @@
 <%= render "components/dashboard/page" do |p| %>
   <% p.header_title "Staff" %>
   <% p.actions do %>
-    <%= link_to "Invite Staff", new_user_invitation_path, class: "btn btn-primary" %><br>
-  <% end %>
-
-  <% p.content do %>
-    <div class="row">
-      <div class="col-lg-12 col-md-12 col-12">
-        <!-- Page Header -->
-        <div class="border-bottom pb-3 mb-3 d-flex justify-content-between align-items-center">
-          <div class="nav btn-group" role="tablist">
-            <button class="btn btn-outline-secondary" data-bs-toggle="tab" data-bs-target="#tabPaneGrid" role="tab" aria-controls="tabPaneGrid" aria-selected="false" tabindex="-1">
-              <span class="fe fe-grid"></span>
-            </button>
-            <button class="btn btn-outline-secondary active" data-bs-toggle="tab" data-bs-target="#tabPaneList" role="tab" aria-controls="tabPaneList" aria-selected="true">
-              <span class="fe fe-list"></span>
-            </button>
+    <div class='d-flex align-items-center gap-2'>
+      <div class="row">
+        <div class="col-lg-12 col-md-12 col-12">
+          <!-- Page Header -->
+          <div class="border-bottom d-flex justify-content-between align-items-center">
+            <div class="nav btn-group" role="tablist">
+              <button class="btn btn-outline-secondary" data-bs-toggle="tab" data-bs-target="#tabPaneGrid" role="tab" aria-controls="tabPaneGrid" aria-selected="false" tabindex="-1">
+                <span class="fe fe-grid"></span>
+              </button>
+              <button class="btn btn-outline-secondary active" data-bs-toggle="tab" data-bs-target="#tabPaneList" role="tab" aria-controls="tabPaneList" aria-selected="true">
+                <span class="fe fe-list"></span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
+      <%= link_to "Invite Staff", new_user_invitation_path, class: "btn btn-primary" %><br>
     </div>
+  <% end %>
 
+  <% p.content do %>
     <div class="row">
       <div class="col-lg-12 col-md-12 col-12">
         <!-- Tab -->

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -15,6 +15,10 @@ crumb :organization_profile do |organization|
   link "Edit Profile", edit_organization_profile_path(organization)
 end
 
+crumb :staff_index do
+  link "Staff", staff_index_path
+end
+
 # crumb :projects do
 #   link "Projects", projects_path
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,5 +1,5 @@
 crumb :root do
-  link "Home", root_path
+  link "Home", dashboard_index_path
 end
 
 crumb :dashboard_pets do
@@ -9,6 +9,10 @@ end
 crumb :dashboard_pet do |pet|
   link pet.name, pet_path(pet)
   parent :dashboard_pets
+end
+
+crumb :organization_profile do |organization|
+  link "Edit Profile", edit_organization_profile_path(organization)
 end
 
 # crumb :projects do


### PR DESCRIPTION
# 🔗 Issue
N/A

# ✍️ Description
I saw that there were a number of pages that weren't conforming to the theme. This PR addresses a few of them (see below for snapshots). A few main points:

- The layout created wasn't being used in the pets#show page and various others. This use of the shared layout enforces more the styling patterns. 
- Search in pets#index updated to match the inline approach in Geeks Theme
- Included a `sub_header` on the main page layout component
- Coloring adjustments on buttons

I didn't include adjusting the pet#new or staff#new page as I'am not exactly sure the style we want to introduce yet.

The goal of this is to help introduce a more consistent pattern across the application for visual appeal and functionality.

# 📷 Screenshots/Demos
<img width="1872" alt="Screenshot 2023-12-09 at 09 27 45" src="https://github.com/rubyforgood/pet-rescue/assets/11335191/fde5c6a4-278d-48cb-9f36-958281c35883">
<img width="1885" alt="Screenshot 2023-12-09 at 09 27 50" src="https://github.com/rubyforgood/pet-rescue/assets/11335191/cfac55ba-305a-442c-9c10-f6aaf7244ad9">
<img width="1902" alt="Screenshot 2023-12-09 at 09 34 47" src="https://github.com/rubyforgood/pet-rescue/assets/11335191/835fa5b2-e5d7-4d14-991c-4eec8de42bd9">
<img width="1907" alt="Screenshot 2023-12-09 at 09 34 50" src="https://github.com/rubyforgood/pet-rescue/assets/11335191/5b708bcc-d398-4e0e-ac25-fc1f8ae52d0a">
