### PR TITLE
Improve image table design

### DIFF
--- a/app/views/components/_image_attachment_table.html.erb
+++ b/app/views/components/_image_attachment_table.html.erb
@@ -3,34 +3,43 @@
   <div class="table-responsive overflow-y-hidden">
     <table class="table mb-0 text-nowrap table-hover table-centered">
       <thead>
-      <tr>
-        <th scope="col"></th>
-        <th scope="col"></th>
-      </tr>
+        <tr>
+          <th scope="col">Image</th>
+          <th scope="col">Filename</th>
+          <th scope="col"></th>
+        </tr>
       </thead>
       <tbody>
-      <% if @pet.images.attached? %>
-        <% @pet.images.each do |image| %>
-          <tr>
-            <td>
-              <div class="d-flex align-items-center">
-                <div class="icon-shape icon-xxxl rounded-3 d-flex flex-column">
-                  <%= image_tag image, class: 'card-img' %>
-                  <%= image.filename %>
+        <% if @pet.images.attached? %>
+          <% @pet.images.each do |image| %>
+            <tr>
+              <td>
+                <div class="d-flex align-items-center">
+                  <div class="icon-shape img-4by3-lg rounded-3">
+                    <%= link_to(image_tag(image, class: 'card-img'), rails_blob_path(image, disposition: 'attachment')) %>
+                  </div>
                 </div>
-              </div>
-            </td>
-            <td>
-              <%= link_to t('general.delete'),
-                    purge_attachment_path(image.id),
-                    data: {
-                      turbo_confirm: "Do you want to delete this image?", 
-                      turbo_method: "delete" },
-                    class: 'btn btn-outline-danger' %>
+              </td>
+              <td>
+                <%= link_to image.filename.to_s, rails_blob_path(image, disposition: 'attachment') %>
+              </td>
+              <td>
+                <%= link_to t('general.delete'),
+                      purge_attachment_path(image.id),
+                      data: {
+                        turbo_confirm: "Do you want to delete this image?",
+                        turbo_method: "delete" },
+                      class: 'btn btn-outline-danger' %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <td colspan="3">
+              No images attached.
             </td>
           </tr>
         <% end %>
-      <% end %>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
# 🔗 Issue
Resolves #351 

# ✍️ Description
Improved the photos table by formatting the design of the table and adding links to download the image when clicking on the image or the filename.

# 📷 Screenshots/Demos
<img width="738" alt="table" src="https://github.com/rubyforgood/pet-rescue/assets/3309779/a4848917-8f81-4f6a-a8f0-233e721c0f6a">
