### PR TITLE
Add 'No files attached.' to the Pet File tab

### DIFF
--- a/app/views/components/_file_attachment_table.html.erb
+++ b/app/views/components/_file_attachment_table.html.erb
@@ -11,28 +11,36 @@
         </tr>
         </thead>
         <tbody>
-        <% @pet.files.each do |file| %>
-          <tr>
-            <td>
-              <%= link_to file.filename, rails_blob_path(file, disposition: 'attachment') %>
-            </td>
-            <td>
-              <%= file.created_at.strftime("%Y-%m-%d") %>
-            </td>
-            <td>
-              <%= link_to t('general.download'),
-                rails_blob_path(file, disposition: 'attachment'),
-                class: 'btn btn-outline-success' %>
+          <% if @pet.files.attached? %>
+            <% @pet.files.each do |file| %>
+              <tr>
+                <td>
+                  <%= link_to file.filename, rails_blob_path(file, disposition: 'attachment') %>
+                </td>
+                <td>
+                  <%= file.created_at.strftime("%Y-%m-%d") %>
+                </td>
+                <td>
+                  <%= link_to t('general.download'),
+                    rails_blob_path(file, disposition: 'attachment'),
+                    class: 'btn btn-outline-success' %>
 
-              <%= link_to t('general.delete'),
-                  purge_attachment_path(file.id),
-                  data: {
-                    turbo_confirm: "Do you want to delete this image?", 
-                    turbo_method: "delete" },
-                  class: 'btn btn-outline-danger' %>
-            </td>
-          </tr>
-        <% end %>
+                  <%= link_to t('general.delete'),
+                      purge_attachment_path(file.id),
+                      data: {
+                        turbo_confirm: "Do you want to delete this image?",
+                        turbo_method: "delete" },
+                      class: 'btn btn-outline-danger' %>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
+            <tr>
+              <td colspan="3">
+                No files attached.
+              </td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/376

# ✍️ Description
Add 'No files attached.' to the Pet File tab if there are no uploads

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
