### PR TITLE
Add images for organization profiles

### DIFF
--- a/app/controllers/organizations/organization_profiles_controller.rb
+++ b/app/controllers/organizations/organization_profiles_controller.rb
@@ -21,6 +21,7 @@ class Organizations::OrganizationProfilesController < Organizations::BaseControl
       :phone_number,
       :email,
       :about_us,
+      :append_avatar,
       location_attributes: %i[city_town country province_state]
     )
   end

--- a/app/controllers/organizations/organization_profiles_controller.rb
+++ b/app/controllers/organizations/organization_profiles_controller.rb
@@ -8,7 +8,7 @@ class Organizations::OrganizationProfilesController < Organizations::BaseControl
   def update
     @organization_profile = Current.organization.profile
     if @organization_profile.update(organization_profile_params)
-      redirect_to dashboard_index_path, notice: "Your profile has been updated!"
+      redirect_to edit_organization_profile_path, notice: "Your profile has been updated!"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/models/organization_profile.rb
+++ b/app/models/organization_profile.rb
@@ -22,6 +22,8 @@
 #  fk_rails_...  (organization_id => organizations.id)
 #
 class OrganizationProfile < ApplicationRecord
+  include Avatarable
+
   belongs_to :location
   belongs_to :organization, inverse_of: :profile
   accepts_nested_attributes_for :location

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -56,7 +56,7 @@
                 <i>(we need your current password to confirm your changes)</i><br />
               </div>
 
-              <%= render partial: 'partials/avatarable_form', locals: { resource: resource, form: f } %>
+              <%= render partial: 'partials/avatarable_form', locals: { resource: resource, form: f, picture_shape: 'circle' } %>
 
               <div class="actions">
                 <%= f.submit "Update", class: 'btn btn-outline-dark mt-3 mb-3',

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -2,7 +2,11 @@
   <div class="vh-100" data-simplebar>
     <!-- Brand logo -->
     <p class="navbar-brand flex-column">
-      <%= current_organization_name %>
+      <% if Current.organization.profile.avatar.attached? %>
+        <%= image_tag Current.organization.profile.avatar, alt: current_organization_name, title: current_organization_name, class: 'rounded-1' %>
+      <% else %>
+        <%= current_organization_name %>
+      <% end %>
     </p>
 
     <!-- Navbar nav -->

--- a/app/views/organizations/organization_profiles/_form.html.erb
+++ b/app/views/organizations/organization_profiles/_form.html.erb
@@ -71,7 +71,7 @@
 
       <!-- Third Column -->
       <div class="col-lg-6">
-        <%= render partial: 'partials/avatarable_form', locals: { resource: profile, form: form } %>
+        <%= render partial: 'partials/avatarable_form', locals: { resource: profile, form: form, picture_shape: 'rectangle' } %>
       </div>
 
     </div>

--- a/app/views/organizations/organization_profiles/_form.html.erb
+++ b/app/views/organizations/organization_profiles/_form.html.erb
@@ -4,26 +4,7 @@
       <%= t '.please_fix_the_errors' %>
     </div>
   <% end %>
-  <hr class="my-5">
-    <!-- Avatar section- not yet functional -->
-    <div class="d-lg-flex align-items-center justify-content-between">
-      <div class="d-flex align-items-center mb-4 mb-lg-0">
-        <!-- Avatar Image -->
-        <img src="../assets/images/avatar/avatar-3.jpg" id="img-uploaded" class="avatar-xl rounded-circle" alt="avatar">
 
-        <!-- Avatar Details -->
-        <div class="ms-3">
-          <h4 class="mb-0">Your avatar</h4>
-          <p class="mb-0">PNG or JPG, size must be between 10kb and 1Mb</p>
-        </div>
-      </div>
-
-      <div>
-        <a href="#" class="btn btn-outline-secondary btn-sm">Update</a>
-        <a href="#" class="btn btn-outline-danger btn-sm">Delete</a>
-      </div>
-    </div>
-  <hr class="my-5">
   <div class='card-body'>
     <div class="d-lg-flex align-items-center justify-content-between">
       <h3 class="mb-1">Organization Details<h3>
@@ -87,6 +68,12 @@
           <% end %>
         </div>
       </div>
+
+      <!-- Third Column -->
+      <div class="col-lg-6">
+        <%= render partial: 'partials/avatarable_form', locals: { resource: profile, form: form } %>
+      </div>
+
     </div>
 
     <div class="row mt-3">

--- a/app/views/partials/_avatarable_form.html.erb
+++ b/app/views/partials/_avatarable_form.html.erb
@@ -16,7 +16,7 @@
   <div class='form-group mt-3'>
     <%= form.file_field :append_avatar, 
                         class: "custom-attachments",
-                        label: 'Attach images' %>
+                        label: 'Attach picture' %>
 
   </div>
 <% end %>

--- a/app/views/partials/_avatarable_form.html.erb
+++ b/app/views/partials/_avatarable_form.html.erb
@@ -7,7 +7,7 @@
       <% if picture_shape == 'circle' %>
         <%= image_tag resource.avatar, class: 'avatar-xxl rounded-circle' %>
       <% elsif picture_shape == 'rectangle' %>
-        <%= image_tag resource.avatar, class: 'avatar-xxl rounded-1 w-auto' %>
+        <%= image_tag resource.avatar, class: 'rounded-1', style: 'max-height:7.5rem;max-width:100%' %>
       <% end %>
       
       <%= link_to t('general.delete'),

--- a/app/views/partials/_avatarable_form.html.erb
+++ b/app/views/partials/_avatarable_form.html.erb
@@ -4,7 +4,11 @@
       Current picture
     </label>
     <div class='d-flex flex-column align-items-center'>
-      <%= image_tag resource.avatar, class: 'avatar-xxl rounded-circle' %>
+      <% if picture_shape == 'circle' %>
+        <%= image_tag resource.avatar, class: 'avatar-xxl rounded-circle' %>
+      <% elsif picture_shape == 'rectangle' %>
+        <%= image_tag resource.avatar, class: 'avatar-xxl rounded-1 w-auto' %>
+      <% end %>
       
       <%= link_to t('general.delete'),
                   purge_attachment_path(resource.avatar.id),

--- a/test/integration/organization_profile/organization_profile_edit_test.rb
+++ b/test/integration/organization_profile/organization_profile_edit_test.rb
@@ -12,9 +12,6 @@ class OrganizationProfile::EditProfileTest < ActionDispatch::IntegrationTest
   end
 
   test "all expected fields are present on the edit organization profile page" do
-    assert_select "h4", text: "Your avatar"
-    assert_select "p", text: "PNG or JPG, size must be between 10kb and 1Mb"
-
     assert_select "label", text: "Phone number"
     assert_select "input[name='organization_profile[phone_number]'][type='tel']"
 
@@ -26,6 +23,9 @@ class OrganizationProfile::EditProfileTest < ActionDispatch::IntegrationTest
 
     assert_select "label", text: "City/Town"
     assert_select "input[name='organization_profile[location_attributes][city_town]'][type='text']"
+
+    assert_select "label", text: "Attach picture"
+    assert_select "input[name='organization_profile[append_avatar]']"
 
     assert_select 'input[type="submit"][value="Save profile"]'
   end
@@ -41,7 +41,8 @@ class OrganizationProfile::EditProfileTest < ActionDispatch::IntegrationTest
           country: "United States",
           province_state: "Colorado",
           city_town: "Golden"
-        }
+        },
+        append_avatar: fixture_file_upload("/logo.png")
       }
     }
     @org_profile.reload
@@ -56,6 +57,7 @@ class OrganizationProfile::EditProfileTest < ActionDispatch::IntegrationTest
     assert_equal "United States", @org_profile.location.country
     assert_equal "Colorado", @org_profile.location.province_state
     assert_equal "Golden", @org_profile.location.city_town
+    assert_equal "logo.png", @org_profile.avatar.filename.sanitized
   end
 
   test "organization profile updates with only some form fields to update" do


### PR DESCRIPTION
# 🔗 Issue
Closes #164.

# ✍️ Description
Organization admins can now upload a picture for their organization. The picture is displayed in the dashboard navbar, and on the `/organization_profile/edit` page.

This feature relies on previous work done for user avatars, through the `Avatarable` concern and view partial. I tried to reuse as much of the existing code as possible, but if there are any suggestions for improvement please let me know.

A couple other pages could benefit from displaying the organization logo instead of text, namely:
- `app/views/layouts/shared/_navbar.html.erb` line 4
- `app/views/devise/sessions/new.html.erb` line 13

I have not modified these pages yet.

# 📷 Screenshots/Demos
https://github.com/rubyforgood/pet-rescue/assets/85654561/1f9f293a-90c3-4b64-b158-6464e056a651


