### PR TITLE
 Create a default pet task and task without a description

### DIFF
--- a/app/models/default_pet_task.rb
+++ b/app/models/default_pet_task.rb
@@ -3,7 +3,7 @@
 # Table name: default_pet_tasks
 #
 #  id              :bigint           not null, primary key
-#  description     :string           not null
+#  description     :string
 #  name            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -21,5 +21,4 @@ class DefaultPetTask < ApplicationRecord
   acts_as_tenant(:organization)
 
   validates :name, presence: true
-  validates :description, presence: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -22,7 +22,6 @@ class Task < ApplicationRecord
   belongs_to :pet
 
   validates :name, presence: true
-  validates :description, presence: true
 
   default_scope { order(created_at: :asc) }
 end

--- a/db/migrate/20240108014846_remove_not_null_constraint_from_default_pet_tasks_description.rb
+++ b/db/migrate/20240108014846_remove_not_null_constraint_from_default_pet_tasks_description.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintFromDefaultPetTasksDescription < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :default_pet_tasks, :description, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_28_081555) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_08_014846) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -132,7 +132,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_28_081555) do
 
   create_table "default_pet_tasks", force: :cascade do |t|
     t.string "name", null: false
-    t.string "description", null: false
+    t.string "description"
     t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/models/default_pet_task_test.rb
+++ b/test/models/default_pet_task_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class DefaultPetTaskTest < ActiveSupport::TestCase
   should validate_presence_of(:name)
-  should validate_presence_of(:description)
 
   test "should have valid factory" do
     assert build(:default_pet_task).valid?

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -35,6 +35,4 @@ class TaskTest < ActiveSupport::TestCase
   end
 
   should validate_presence_of(:name)
-
-  should validate_presence_of(:description)
 end


### PR DESCRIPTION
# 🔗 Issue
[#417 ](https://github.com/rubyforgood/pet-rescue/issues/417)

# ✍️ Description
-  Added migration to remove null constraint for :description field on default_pet_tasks table
-  Removed presence validation on Task and DefaultPetTask model
-  Removed test checks related to :description presence validation


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
