### PR TITLE
Remove safety_assured from migration

### DIFF
--- a/db/migrate/20231228081555_remove_pause_reason_from_pets.rb
+++ b/db/migrate/20231228081555_remove_pause_reason_from_pets.rb
@@ -1,7 +1,5 @@
 class RemovePauseReasonFromPets < ActiveRecord::Migration[7.0]
   def change
-    safety_assured do
-      remove_column :pets, :pause_reason, :integer
-    end
+    remove_column :pets, :pause_reason, :integer
   end
 end


### PR DESCRIPTION
# ✍️ Description

This migration was merged after the removal of the strong_migrations gem. However, it still contained a `safety_assured` block, which led to its failure.
