### PR TITLE
422 fix turbo refresh after pet task delete

### DIFF
--- a/app/controllers/organizations/invitations_controller.rb
+++ b/app/controllers/organizations/invitations_controller.rb
@@ -29,4 +29,8 @@ class Organizations::InvitationsController < Devise::InvitationsController
       .permit(:first_name, :last_name, :email,
         staff_account_attributes: [:roles])
   end
+
+  def after_accept_path_for(_resource)
+    dashboard_index_path
+  end
 end

--- a/app/views/organizations/tasks/destroy.turbo_stream.erb
+++ b/app/views/organizations/tasks/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove @task %>


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/422

# ✍️ Description
Added turbo stream view for turbo destroy action

# 📷 Screenshots/Demos

https://github.com/rubyforgood/pet-rescue/assets/131488886/48420839-4b12-4320-919e-8ff26d7f9c55


