### PR TITLE
Handle Error display on user edit registrations and related to avatarable

### DIFF
--- a/app/controllers/organizations/organization_profiles_controller.rb
+++ b/app/controllers/organizations/organization_profiles_controller.rb
@@ -21,7 +21,7 @@ class Organizations::OrganizationProfilesController < Organizations::BaseControl
       :phone_number,
       :email,
       :about_us,
-      :append_avatar,
+      :avatar,
       location_attributes: %i[city_town country province_state]
     )
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -43,7 +43,7 @@ class RegistrationsController < Devise::RegistrationsController
       :password_confirmation,
       :signup_role,
       :current_password,
-      :append_avatar)
+      :avatar)
   end
 
   def after_sign_up_path_for(resource)

--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -4,9 +4,9 @@ module Avatarable
   included do
     has_one_attached :avatar
 
-    validates :avatar, content_type: { in: ["image/png", "image/jpeg"],
-                                      message: "must be PNG or JPEG" },
-      size: { between: 10.kilobyte..1.megabytes,
-             message: "size must be between 10kb and 1Mb" }
+    validates :avatar, content_type: {in: ["image/png", "image/jpeg"],
+                                      message: "must be PNG or JPEG"},
+      size: {between: 10.kilobyte..1.megabytes,
+             message: "size must be between 10kb and 1Mb"}
   end
 end

--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -4,13 +4,9 @@ module Avatarable
   included do
     has_one_attached :avatar
 
-    validates :avatar, content_type: {in: ["image/png", "image/jpeg"],
-                                      message: "must be PNG or JPEG"},
-      size: {between: 10.kilobyte..1.megabytes,
-             message: "size must be between 10kb and 1Mb"}
-  end
-
-  def append_avatar=(attachable)
-    avatar.attach(attachable)
+    validates :avatar, content_type: { in: ["image/png", "image/jpeg"],
+                                      message: "must be PNG or JPEG" },
+      size: { between: 10.kilobyte..1.megabytes,
+             message: "size must be between 10kb and 1Mb" }
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,7 +11,6 @@
             <%= bootstrap_form_for(resource, as: resource_name,
                                   url: registration_path(resource_name),
                                   html: { method: :put }) do |f| %>
-              <%= render "devise/shared/error_messages", resource: resource %>
 
               <div class="form-group mb-3">
                 <%= f.email_field :email, autofocus: true, autocomplete: "email",

--- a/app/views/partials/_avatarable_form.html.erb
+++ b/app/views/partials/_avatarable_form.html.erb
@@ -17,7 +17,7 @@
   </div>
 <% else %>
   <div class='form-group mt-3'>
-    <%= form.file_field :append_avatar, 
+    <%= form.file_field :avatar, 
                         class: "custom-attachments",
                         label: 'Attach picture' %>
   </div>

--- a/test/integration/organization_profile/organization_profile_edit_test.rb
+++ b/test/integration/organization_profile/organization_profile_edit_test.rb
@@ -25,7 +25,7 @@ class OrganizationProfile::EditProfileTest < ActionDispatch::IntegrationTest
     assert_select "input[name='organization_profile[location_attributes][city_town]'][type='text']"
 
     assert_select "label", text: "Attach picture"
-    assert_select "input[name='organization_profile[append_avatar]']"
+    assert_select "input[name='organization_profile[avatar]']"
 
     assert_select 'input[type="submit"][value="Save profile"]'
   end
@@ -41,7 +41,7 @@ class OrganizationProfile::EditProfileTest < ActionDispatch::IntegrationTest
           province_state: "Colorado",
           city_town: "Golden"
         },
-        append_avatar: fixture_file_upload("/logo.png")
+        avatar: fixture_file_upload("/logo.png")
       }
     }
     @org_profile.reload

--- a/test/shared/avatarable_shared_tests.rb
+++ b/test/shared/avatarable_shared_tests.rb
@@ -7,7 +7,7 @@ module AvatarableSharedTests
         should "behave as avatarable" do
           assert_includes User.included_modules, Avatarable
 
-          assert subject, respond_to?(:append_avatar=)
+          assert subject, respond_to?(:avatar=)
         end
 
         context "validations" do

--- a/test/system/registration_test.rb
+++ b/test/system/registration_test.rb
@@ -20,10 +20,7 @@ class RegistrationTest < ApplicationSystemTestCase
       attach_file("Attach picture", Rails.root + "test/fixtures/files/blank.pdf")
       fill_in "Current password", with: @user.password
       click_on "Update"
-
-      alert = first("div.alert")
-
-      assert !alert.nil?
+      assert_selector("div.invalid-feedback", text: "must be PNG or JPEG")
     end
 
     should "direct to home index path with valid upload" do


### PR DESCRIPTION
🔗 Issue
#426 

# ✍️ Description
- Removed errors appearing on top of user > edit registrations
- Handled error display on both user > edit registrations as well as Organizational Profiles edit where earlier proper error message was not displayed for Attach Picture
- Removed append_avatar method from avatarable and changed all occurrences of :append_avatar to :avatar
- Handled test cases as well
 