### PR TITLE
Added Links to Corresponding Profiles

### DIFF
--- a/app/views/organizations/pets/tabs/_applications.html.erb
+++ b/app/views/organizations/pets/tabs/_applications.html.erb
@@ -1,6 +1,6 @@
 <div class="card">
   <div class="card-header">
-    <h4 class="mb-0"><%= pet.name %></h4>
+    <h4 class="mb-0"><%= link_to pet.name, pet_path(pet), class: "link-underline link-underline-opacity-0" %></h4>
   </div>
   <div class="card-body table-responsive">
     <table class="table mb-0 text-nowrap table-hover table-centered">
@@ -18,7 +18,8 @@
           <tr>
             <!-- applicant -->
             <td class="align-middle">
-                <%= app.applicant_name %>
+              <%= link_to app.applicant_name, profile_review_path(app.adopter_account.adopter_profile), 
+                            class: "link-underline link-underline-opacity-0"  %>
             </td>
             <!-- profile -->
             <td class="align-middle text-center">

--- a/test/controllers/organizations/adoption_application_reviews_controller_test.rb
+++ b/test/controllers/organizations/adoption_application_reviews_controller_test.rb
@@ -25,7 +25,7 @@ class Organizations::AdoptionApplicationReviewsControllerTest < ActionDispatch::
       should "return applications for a specific pet name" do
         get adoption_application_reviews_url, params: {q: {name_i_cont: "Pango"}}
         assert_response :success
-        assert_match "Pango", @response.body
+        assert_select "a.link-underline.link-underline-opacity-0", text: "Pango"
         refute_match "Tycho", @response.body
       end
     end
@@ -46,7 +46,7 @@ class Organizations::AdoptionApplicationReviewsControllerTest < ActionDispatch::
       should "return applications for a specific applicant name" do
         get adoption_application_reviews_url, params: {q: {adopter_applications_applicant_name_i_cont: "Attenborough"}}
         assert_response :success
-        assert_match "Attenborough, David", @response.body
+        assert_select "a.link-underline.link-underline-opacity-0", text: "Attenborough, David"
         refute_match "Goodall, Jane", @response.body
       end
     end


### PR DESCRIPTION
# 🔗 Issue
#429 

# ✍️ Description
- Added corresponding profile links to both pet and adopter names
- Asserted the presence of link in controller test

# 📷 Screenshots/Demos
![Screenshot 2024-01-12 004216](https://github.com/rubyforgood/pet-rescue/assets/18101543/cb816208-074d-42ff-864d-f6aec3ae2766)

