### PR TITLE
431 update new adoption button

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -7,9 +7,9 @@ class MatchesController < ApplicationController
 
     if @match.save
       set_statuses_to_adoption_made
-      redirect_to adopter_applications_path, notice: "Pet successfully adopted."
+      redirect_back_or_to dashboard_index_path, notice: "Pet successfully adopted."
     else
-      redirect_to adopter_applications_path, alert: "Error."
+      redirect_back_or_to dashboard_index_path, alert: "Error."
 
     end
   end

--- a/app/views/organizations/pets/tabs/_applications.html.erb
+++ b/app/views/organizations/pets/tabs/_applications.html.erb
@@ -10,7 +10,7 @@
           <th scope="col" class="text-center">Profile</th>
           <th scope="col" class="text-center">Edit</th>
           <th scope="col">Status</th>
-          <th scope="col" class="text-center">New Adoption</th>
+          <th scope="col"></th>
         </tr>
       </thead>
       <tbody>
@@ -18,7 +18,7 @@
           <tr>
             <!-- applicant -->
             <td class="align-middle">
-                <%= app.applicant_name %>
+              <%= app.applicant_name %>
             </td>
             <!-- profile -->
             <td class="align-middle text-center">
@@ -42,17 +42,21 @@
                 <%= app.status.titleize %>
               </span>
             </td>
-            <!-- create --> 
+            <!-- create -->
             <td class="align-middle text-center">
               <% if app.status == 'successful_applicant' %>
                 <!--create adoption button-->
-                  <%= link_to create_adoption_path(pet_id: app.pet.id, 
+                <%= button_to "New Adoption", create_adoption_path(pet_id: app.pet.id, 
                                                   adopter_account_id: app.adopter_account.id),
-                              class: "link-underline link-underline-opacity-0",
+                              class: "btn btn-outline-primary",
                               data: { turbo_method: :post, 
-                                      turbo_confirm: "Click OK to finalize this adoption." } do %>
-                    <i class="fe fe-plus" aria-label="create new adoption"></i>
-                  <% end %>
+                                      turbo_confirm: "Click OK to finalize this adoption." } %>
+              <% else %>
+                <span class="d-inline-block" tabindex="0"
+                data-bs-toggle="tooltip" title="Finalize adoption">
+                  <button type="button" class="btn btn-outline-secondary"
+                disabled>New Adoption</button>
+                </span>
               <% end %>
             </td>
           </tr>


### PR DESCRIPTION
Resolves #431 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
- Update "New Adoption" Button (Enabled only when status is "Successful Applicant")
- Add tooltip on hover of disabled button (text to can be changed based on stakeholder feedback)
- Fix redirect in matches controller to redirect back to the page the user navigated from (Either pets page or application reviews page) 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
[Screencast from 01-12-2024 09:58:31 AM.webm](https://github.com/rubyforgood/pet-rescue/assets/16829344/dea4947d-3b55-46dc-ae98-979118c62100)

