### PR TITLE
Add colour shading to background of each task depending on its 'status' 

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -28,16 +28,15 @@ class Task < ApplicationRecord
   default_scope { order(created_at: :asc) }
 
   def determine_shading_class
-    case
-    when completed?
+    if completed?
       "bg-success-subtle"
-    when due_date.present?
+    elsif due_date.present?
       check_due_date
     end
   end
 
   def check_due_date
-    if self.due_date < Date.today
+    if due_date < Date.today
       "bg-danger-subtle"
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -26,4 +26,19 @@ class Task < ApplicationRecord
   validates :description, presence: true
 
   default_scope { order(created_at: :asc) }
+
+  def determine_shading_class
+    case
+    when completed?
+      "bg-success-subtle"
+    when due_date.present?
+      check_due_date
+    end
+  end
+
+  def check_due_date
+    if self.due_date < Date.today
+      "bg-danger-subtle"
+    end
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -27,17 +27,7 @@ class Task < ApplicationRecord
 
   default_scope { order(created_at: :asc) }
 
-  def determine_shading_class
-    if completed?
-      "bg-success-subtle"
-    elsif due_date.present?
-      check_due_date
-    end
-  end
-
-  def check_due_date
-    if due_date < Date.today
-      "bg-danger-subtle"
-    end
+  def overdue?
+    due_date < Time.current if due_date
   end
 end

--- a/app/views/organizations/pets/tasks/_tasks.html.erb
+++ b/app/views/organizations/pets/tasks/_tasks.html.erb
@@ -11,7 +11,7 @@
         <ul class="list-group">
           <% @pet.tasks.order(due_date: :asc).each do |task| %>
             <%= turbo_frame_tag task do %>
-              <li class="list-group-item">
+              <li class="list-group-item <%= task.determine_shading_class %>">
                 <div class="d-flex justify-content-between
                             align-items-center">
 

--- a/app/views/organizations/pets/tasks/_tasks.html.erb
+++ b/app/views/organizations/pets/tasks/_tasks.html.erb
@@ -11,7 +11,7 @@
         <ul class="list-group">
           <% @pet.tasks.order(due_date: :asc).each do |task| %>
             <%= turbo_frame_tag task do %>
-              <li class="list-group-item <%= task.determine_shading_class %>">
+              <li class="list-group-item <%= class_names({ 'bg-danger-subtle': task.overdue? && !task.completed, 'bg-success-subtle': task.completed }) %>">
                 <div class="d-flex justify-content-between
                             align-items-center">
 


### PR DESCRIPTION
This pr addressed #454  . I have updated the relevant code and add color shading to background of each task depending on its status.
![image](https://github.com/rubyforgood/pet-rescue/assets/116902652/28fd36ac-c19e-4f38-895a-2adf123a9b40)
