### PR TITLE
Default tasks - due in days

### DIFF
--- a/app/controllers/organizations/default_pet_tasks_controller.rb
+++ b/app/controllers/organizations/default_pet_tasks_controller.rb
@@ -48,6 +48,6 @@ class Organizations::DefaultPetTasksController < Organizations::BaseController
   private
 
   def task_params
-    params.require(:default_pet_task).permit(:name, :description)
+    params.require(:default_pet_task).permit(:name, :description, :due_in_days)
   end
 end

--- a/app/models/default_pet_task.rb
+++ b/app/models/default_pet_task.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  description     :string
+#  due_in_days     :integer
 #  name            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/models/default_pet_task.rb
+++ b/app/models/default_pet_task.rb
@@ -22,4 +22,5 @@ class DefaultPetTask < ApplicationRecord
   acts_as_tenant(:organization)
 
   validates :name, presence: true
+  validates_numericality_of :due_in_days, only_integer: true, greater_than_or_equal_to: 0, allow_nil: true
 end

--- a/app/services/organizations/default_pet_task_service.rb
+++ b/app/services/organizations/default_pet_task_service.rb
@@ -11,7 +11,8 @@ class Organizations::DefaultPetTaskService
         pet_id: @pet.id,
         name: task.name,
         description: task.description,
-        completed: false
+        completed: false,
+        due_date: task.due_in_days&.days&.from_now&.beginning_of_day
       }
     end
   end

--- a/app/views/organizations/default_pet_tasks/_form.html.erb
+++ b/app/views/organizations/default_pet_tasks/_form.html.erb
@@ -9,6 +9,10 @@
         <%= f.text_area :description, class: 'form-control', rows: 3 %>
       </div>
 
+      <div class="form-group">
+        <%= f.number_field :due_in_days, class: 'form-control', help: 'The task will be due this number of days after the pet is created.' %>
+      </div>
+
       <%= f.submit t('general.save'), class: 'btn btn-primary' %>
       <%= link_to t('general.cancel'), default_pet_tasks_path, class: 'btn btn-secondary' %>
     <% end %>

--- a/app/views/organizations/default_pet_tasks/index.html.erb
+++ b/app/views/organizations/default_pet_tasks/index.html.erb
@@ -18,6 +18,7 @@
               <tr>
                 <th scope="col">Name</th>
                 <th scope="col">Description</th>
+                <th scope="col">Due After</th>
                 <th scope="col">Recurrence</th>
                 <th scope="col"></th>
               </tr>
@@ -30,6 +31,9 @@
                   </td>
                   <td>
                     <%= task.description %>
+                  </td>
+                  <td>
+                    <%= task.due_in_days ? pluralize(task.due_in_days, "day") : "" %>
                   </td>
                   <td>
                     -

--- a/db/migrate/20240201133430_add_due_in_days_to_default_tasks.rb
+++ b/db/migrate/20240201133430_add_due_in_days_to_default_tasks.rb
@@ -1,0 +1,5 @@
+class AddDueInDaysToDefaultTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :default_pet_tasks, :due_in_days, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_22_001134) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_01_133430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_001134) do
     t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "due_in_days"
     t.index ["organization_id"], name: "index_default_pet_tasks_on_organization_id"
   end
 

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -238,12 +238,13 @@ ActsAsTenant.with_tenant(@organization) do
     )
     pet.images.attach(io: File.open(path), filename: "hero.jpg")
 
+    due_dates = [Date.today - 1.day, Date.today, Date.today + 30.days]
     DefaultPetTask.all.each_with_index do |task, index|
       Task.create!(
         pet_id: pet.id,
         name: task.name,
         description: task.description,
-        due_date: (Date.today + (index - 1).days)
+        due_date: due_dates[index]
       )
     end
   end

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -238,11 +238,13 @@ ActsAsTenant.with_tenant(@organization) do
     )
     pet.images.attach(io: File.open(path), filename: "hero.jpg")
 
-    DefaultPetTask.all.each do |task|
+    due_dates = [Date.today - 1.day, Date.today, Date.today + 30.days]
+    DefaultPetTask.all.each_with_index do |task, index|
       Task.create!(
         pet_id: pet.id,
         name: task.name,
-        description: task.description
+        description: task.description,
+        due_date: due_dates[index]
       )
     end
   end

--- a/test/controllers/organizations/default_pet_tasks_controller_test.rb
+++ b/test/controllers/organizations/default_pet_tasks_controller_test.rb
@@ -33,7 +33,8 @@ class Organizations::DefaultPetTasksControllerTest < ActionDispatch::Integration
         post default_pet_tasks_path, params: {
           default_pet_task: {
             name: "New Task",
-            description: "Descrition of new Task"
+            description: "Descrition of new Task",
+            due_in_days: 5
           }
         }
       end

--- a/test/models/default_pet_task_test.rb
+++ b/test/models/default_pet_task_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class DefaultPetTaskTest < ActiveSupport::TestCase
   should validate_presence_of(:name)
+  should validate_numericality_of(:due_in_days).only_integer.is_greater_than_or_equal_to(0).allow_nil
 
   test "should have valid factory" do
     assert build(:default_pet_task).valid?

--- a/test/services/organizations/default_pet_task_service_test.rb
+++ b/test/services/organizations/default_pet_task_service_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Organizations::DefaultPetTaskServiceTest < ActiveSupport::TestCase
+  test "creates tasks from the organization's default tasks" do
+    organization = create(:organization)
+    default_task = create(:default_pet_task, organization: organization)
+    pet = create(:pet, organization: organization)
+
+    Organizations::DefaultPetTaskService.new(pet).create_tasks
+
+    assert_equal 1, pet.tasks.count
+    assert_equal default_task.name, pet.tasks.first.name
+    assert_nil pet.tasks.first.due_date
+  end
+
+  test "creates tasks with due_date set based on the default task's due_in_days" do
+    organization = create(:organization)
+    default_task = create(:default_pet_task, organization: organization, due_in_days: 5)
+    pet = create(:pet, organization: organization)
+
+    Organizations::DefaultPetTaskService.new(pet).create_tasks
+
+    assert_equal 5.days.from_now.beginning_of_day, pet.tasks.first.due_date
+  end
+end

--- a/test/services/organizations/default_pet_task_service_test.rb
+++ b/test/services/organizations/default_pet_task_service_test.rb
@@ -15,7 +15,7 @@ class Organizations::DefaultPetTaskServiceTest < ActiveSupport::TestCase
 
   test "creates tasks with due_date set based on the default task's due_in_days" do
     organization = create(:organization)
-    default_task = create(:default_pet_task, organization: organization, due_in_days: 5)
+    create(:default_pet_task, organization: organization, due_in_days: 5)
     pet = create(:pet, organization: organization)
 
     Organizations::DefaultPetTaskService.new(pet).create_tasks


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
#456 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Adds a `due_in_days` column to default tasks.  When a task is created from the default task, its due date is set to `due_in_days` days from now.  

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

<img width="645" alt="Screenshot 2024-02-01 at 9 57 47 AM" src="https://github.com/rubyforgood/pet-rescue/assets/32289/f2f019e0-7047-4b59-908f-3b392a516219">
<img width="958" alt="Screenshot 2024-02-01 at 9 58 19 AM" src="https://github.com/rubyforgood/pet-rescue/assets/32289/15b607b7-7e73-4a89-96f3-15b0e152ed29">



