### PR TITLE
Change task model to allow optional description

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,7 +23,6 @@ class Task < ApplicationRecord
   belongs_to :pet
 
   validates :name, presence: true
-  validates :description, presence: true
 
   default_scope { order(created_at: :asc) }
 end


### PR DESCRIPTION
Resolves #462 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Fixes error on new Pet creation due to 'default tasks' with optional descriptions and 'tasks' with mandatory descriptions.

-Remove presence: true validation from task's model