### PR TITLE
Fix test tenant leakage

### DIFF
--- a/test/controllers/organizations/tasks_controller_test.rb
+++ b/test/controllers/organizations/tasks_controller_test.rb
@@ -6,7 +6,7 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:user, :activated_staff, :staff_admin)
     set_organization(@user.organization)
-    @organization = ActsAsTenant.test_tenant
+    @organization = ActsAsTenant.current_tenant
     @pet = create(:pet)
     @task = create(:task, pet: @pet)
     sign_in @user

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :adopter_account do
     transient do
-      organization { ActsAsTenant.test_tenant }
+      organization { ActsAsTenant.current_tenant }
     end
 
     user do
@@ -104,7 +104,7 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.phone_number }
     about_us { Faker::Lorem.paragraph(sentence_count: 4) }
     location
-    organization { ActsAsTenant.test_tenant }
+    organization { ActsAsTenant.current_tenant }
   end
 
   factory :pet do
@@ -117,7 +117,7 @@ FactoryBot.define do
     weight_to { 20 }
     weight_unit { "lb" }
     species { Faker::Number.within(range: 0..1) }
-    organization { ActsAsTenant.test_tenant }
+    organization { ActsAsTenant.current_tenant }
     placement_type { Faker::Number.within(range: 0..2) }
     published { true }
 
@@ -131,13 +131,13 @@ FactoryBot.define do
   end
 
   factory :match do
-    organization { ActsAsTenant.test_tenant }
+    organization { ActsAsTenant.current_tenant }
     pet { association :pet, organization: organization }
     adopter_account { association :adopter_account, :with_adopter_profile, organization: organization }
   end
 
   factory :staff_account do
-    organization { ActsAsTenant.test_tenant }
+    organization { ActsAsTenant.current_tenant }
     user { association :user, organization: organization }
     deactivated_at { nil }
 
@@ -162,7 +162,7 @@ FactoryBot.define do
   factory :default_pet_task do
     name { "MyString" }
     description { "MyText" }
-    organization { ActsAsTenant.test_tenant }
+    organization { ActsAsTenant.current_tenant }
   end
 
   factory :user do
@@ -173,7 +173,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     tos_agreement { true }
 
-    organization { ActsAsTenant.test_tenant }
+    organization { ActsAsTenant.current_tenant }
 
     trait :activated_staff do
       staff_account { association :staff_account, organization: organization }

--- a/test/integration/organization_profile/organization_profile_edit_test.rb
+++ b/test/integration/organization_profile/organization_profile_edit_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class OrganizationProfile::EditProfileTest < ActionDispatch::IntegrationTest
   setup do
-    @org = ActsAsTenant.test_tenant
+    @org = ActsAsTenant.current_tenant
     @org_profile = @org.profile
     admin = create(:user, :staff_admin, organization: @org)
     sign_in admin

--- a/test/models/organization_profile_test.rb
+++ b/test/models/organization_profile_test.rb
@@ -7,7 +7,7 @@ class OrganizationProfileTest < ActiveSupport::TestCase
   end
 
   test "should belong to an organization" do
-    organization = ActsAsTenant.test_tenant
+    organization = ActsAsTenant.current_tenant
     organization_profile = build(:organization_profile, organization: organization)
 
     assert_equal organization_profile.organization.slug, "test"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,7 @@ class ActiveSupport::TestCase
   end
 
   def teardown
+    ActsAsTenant.current_tenant = nil
     ActsAsTenant.test_tenant = nil
     Rails.application.routes.default_url_options[:script_name] = ""
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,9 +30,14 @@ class ActiveSupport::TestCase
     end
   end
 
-  setup do
-    ActsAsTenant.test_tenant = create(:organization, slug: "test")
-    set_organization(ActsAsTenant.test_tenant)
+  setup do |test|
+    if test.is_a?(ActionDispatch::IntegrationTest)
+      ActsAsTenant.test_tenant = create(:organization, slug: "test")
+    else
+      ActsAsTenant.current_tenant = create(:organization, slug: "test")
+    end
+
+    set_organization(ActsAsTenant.current_tenant)
   end
 
   def teardown


### PR DESCRIPTION
# 🔗 Issue
Not for a specific issue but this was causing me problems while working on #450, and I think it's an important enough bug that it should be addressed before I finish that feature.

The problem is that currently `ActsAsTenant.current_tenant` can leak between tests. It could also cause problems with `organization` relation assignment not behaving as expected in tests.

# ✍️ Description
tl;dr: With our current test_helper.rb setup, tenant values will leak between tests depending on how they are used and especially if using methods such as `ActsAsTenant.without_tenant` or `ActsAsTenant.with_tenant` in a test. These changes will prevent this from happening and better match the recommendations from ActsAsTenant.

You can read a full explanation below if you want to find out more about how ActsAsTenant works. I wrote most of it while I was trying to rubber duck this, so it might be rambly lol. Otherwise, you can skip most of it and see the demo section at the bottom for what kind of problems currently exist that this PR would fix.

These changes also better match the [defaults recommended by ActsAsTenant](https://github.com/ErwinM/acts_as_tenant?tab=readme-ov-file#testing).

---

While working on #450, I noticed some weird tenant behavior in my tests. Tests began failing after one specific test. In this test, I swapped the tenant briefly to make a record for a different organization and make sure that the current user could not perform actions on that different organization. You can see a snippet of that code [below](# 📷 Screenshots/Demos).

All the test runs after this specific test would fail with a validation on a tenant. Upon digging into the ActsAsTenant source code, I found the problem.

```ruby
# acts_as_tenant.rb
  def self.current_tenant=(tenant)
    RequestStore.store[:current_tenant] = tenant
  end

  def self.current_tenant
    RequestStore.store[:current_tenant] || test_tenant || default_tenant
  end

  def self.test_tenant=(tenant)
    Thread.current[:test_tenant] = tenant
  end

  def self.test_tenant
    Thread.current[:test_tenant]
  end

  ...
  def self.with_tenant(tenant, &block)
    if block.nil?
      raise ArgumentError, "block required"
    end

    old_tenant = current_tenant
    self.current_tenant = tenant
    value = block.call
    value
  ensure
    self.current_tenant = old_tenant
  end
```
In our tests, we currently are setting `test_tenant` in `test_helper.rb` after each test. We do not set `current_tenant`. However, when **getting** `current_tenant` in tests, we do not get `nil` because `ActsAsTenant` is setup to return `test_tenant` if `current_tenant` is `nil`. That sounds *okay* except when we use a method such as `#with_tenant`.

When using `with_tenant`, we cache the return of `current_tenant` (which is actually the value of `test_tenant`). We then change `current_tenant`'s value to equal the temporary tenant passed into the method and execute the block. To cleanup, the method then sets `current_tenant`' s value to the cached value. However, if you followed along, this is not bringing things to as they were!

before method execution:
```ruby
RequestStore.store[:current_tenant] # nil
Thread.current[:test_tenant] # <test_helper value>
```
after method execution:
```ruby
RequestStore.store[:current_tenant] # <test_helper value>
Thread.current[:test_tenant] # <test_helper value>
```

Then the last step that causes problems is our test `teardown` only clears `test_tenant`. So all tests after this method now have `current_tenant` set to the value from this previous test.
```ruby
# test_helper.rb
  def teardown
    ActsAsTenant.test_tenant = nil
    Rails.application.routes.default_url_options[:script_name] = ""
  end
```
The quick fix to this is to just add `ActsAsTenant.current_tenant = nil` to the teardown. No more leaks. However, there is a little more work to do as currently tests do not use ActsAsTenant as intended.

`#test_tenant` exists as described in the docs for use with "request"/integration tests. They are intended for when middleware is involved. That is why the getter `#current_tenant` method is written as it is. I do not believe it was the intention for `test_tenant` to be used throughout all tests, and I think doing so could result in strange behavior in the future.

One possible problem with how tests are current written is this scenario:
A dev writes a test context that sets `ActsAsTenant.current_tenant = Organization[1]`. Then, a different dev makes a nested context and sees throughout the app other devs setting `test_tenant =`, so they do `ActsAsTenant.test_tenant = Organization[2]`. They then instantiate a `Pet` with FactoryBot.

Would the pet's organization be equal to `test_tenant` or `current_tenant`?

Even if the factory was passed the `test_tenant` organization as a parameter, it would still make it under the `current_tenant` if that model had `acts_as_tenant` called within it! That could be very confusing.

# 📷 Screenshots/Demos
Problem with leakage:
```ruby
# new_file_test.rb
        # ...
        # From test_helper.rb:
        # ActsAsTenant.current_tenant == nil
        # ActsAsTenant.test_tenant == create(:organization, ...)

	context "when pet is from a different organization" do
	  setup do
                @other_organization = create(:organization)
                ActsAsTenant.with_tenant(@other_organization) do
		      @pet = create(:pet, organization: @other_organization)
                end
                # ActsAsTenant.current_tenant == ActsAsTenant.test_tenant
	  end

	  should "return false" do
		assert_equal @action.call, false
	  end
	end
```
This test would pass but then all other tests after it would fail because of the logic explained in [Description](# ✍️ Description).

Theoretical acts_as_tenant problem:
```ruby
# example_test.rb
	setup do
              @organization = create(:organization)
              ActsAsTenant.current_tenant = @organization
	end

	context "when pet is from a different organization" do
	  setup do
                @other_organization = create(:organization)

                ActsAsTenant.test_tenant = @other_organization
                @pet = create(:pet, organization: @other_organization)
                ActsAsTenant.test_tenant = @organization
	  end

	  should "test something" do
		@pet.organization # == @organization, not @other_organization !!!
	  end
	end
```
Note: This theoretical is for illustrative purposes only. I am not trying to say tests should be written like this example. I think tenants should be set in `test_helper` usually, and if tenant needs to be swapped, we should use `ActsAsTenant.with_tenant` or `without_tenant`.