### PR TITLE
471 Sort Pet Tasks

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -24,9 +24,19 @@ class Task < ApplicationRecord
 
   validates :name, presence: true
 
-  default_scope { order(created_at: :asc) }
+  scope :is_not_completed, -> { where(completed: false).or(where(completed: nil)) }
+  scope :is_completed, -> { where(completed: true) }
+  scope :has_due_date, -> { where.not(due_date: nil).order(due_date: :asc) }
+  scope :no_due_date, -> { where(due_date: nil).order(updated_at: :desc) }
 
   def overdue?
     due_date < Time.current if due_date
+  end
+
+  def self.list_ordered
+    Task.is_not_completed.has_due_date +
+      Task.is_not_completed.no_due_date +
+      Task.is_completed.has_due_date +
+      Task.is_completed.no_due_date
   end
 end

--- a/app/views/organizations/pets/tasks/_tasks.html.erb
+++ b/app/views/organizations/pets/tasks/_tasks.html.erb
@@ -8,7 +8,7 @@
               <h4 class="mb-0">Tasks</h4>
               <%= link_to new_pet_task_path(@pet), class: 'btn btn-outline-primary m-3', data: { turbo_frame: dom_id(Task.new) } do %>
                 <div class="d-flex align-items-center">
-                  <i class="fe fe-plus fw-bolder me-2" aria-label="add new task" style="font-size: 22px;"></i> 
+                  <i class="fe fe-plus fw-bolder me-2" aria-label="add new task" style="font-size: 22px;"></i>
                   Add New Task
                 </div>
               <% end %>
@@ -22,20 +22,17 @@
           </div>
           <%= turbo_frame_tag Task.new %>
         </div>
-
         <ul class="list-group">
-          <% @pet.tasks.order(due_date: :asc).each do |task| %>
+          <% @pet.tasks.list_ordered.each do |task| %>
             <%= turbo_frame_tag task do %>
               <li class="list-group-item <%= class_names({ 'bg-danger-subtle': task.overdue? && !task.completed, 'bg-success-subtle': task.completed}) %>">
                 <div class="d-flex justify-content-between
                             align-items-center">
-
                   <div class="d-flex align-items-center">
                     <%= render '/organizations/pets/tasks/tasks_toggle', task: task %>
                     <div style="padding: 0 10px; margin-top: 15px;">
                       <strong class="d-block" ><%= task.name %></strong>
                       <p class='mb-0'> <%= task.description %> </p>
-
                       <% if task.due_date %>
                         <% if task.due_date.to_date == Date.current %>
                           <div class='text-warning'>
@@ -51,10 +48,8 @@
                           </div>
                         <% end %>
                       <% end %>
-
                     </div>
                   </div>
-
                   <!-- Right side: Completion status and action buttons -->
                   <div class="text-right">
                     <div class="d-flex align-items-center justify-content-end">
@@ -67,7 +62,6 @@
             <% end %>
           <% end %>
         </ul>
-        
       </div>
     </div>
   </div>

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -35,4 +35,18 @@ class TaskTest < ActiveSupport::TestCase
   end
 
   should validate_presence_of(:name)
+
+  test "should return tasks list in the correct order" do
+    pet = build(:pet)
+    task1 = create(:task, name: "task1", pet: pet, created_at: 1.day.ago, completed: true)
+    task2 = create(:task, name: "task2", pet: pet, created_at: 2.days.ago, due_date: 1.day.from_now) # completed nil
+    task3 = create(:task, name: "task3", pet: pet, created_at: 3.days.ago, completed: true, due_date: 1.day.from_now)
+    task4 = create(:task, name: "task4", pet: pet, created_at: 4.days.ago, completed: false)
+    task5 = create(:task, name: "task5", pet: pet, created_at: 5.days.ago, completed: false, updated_at: Time.current)
+    task6 = create(:task, name: "task6", pet: pet, created_at: 6.days.ago, due_date: 2.day.from_now) # completed nil
+
+    list = pet.tasks.list_ordered
+
+    assert_equal([task2, task6, task5, task4, task3, task1], [list[0], list[1], list[2], list[3], list[4], list[5]])
+  end
 end


### PR DESCRIPTION
Resolves #471 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This adds a method to the Task model to sort the order in which tasks are returned to the view. I've added scopes for the different criteria then concat the tasks into a single list in the method. I'm not sure if there is a way to do this all in a single query (or if that would provide much benefit) because some parts of the list are ascending and some descending. I am open to suggestions.
    

- [x] Uncompleted pet tasks show above completed pet tasks.

- [x] Uncompleted tasks with a due date show above uncompleted tasks without a due date, and are ordered by due date (ascending) so the closest (or most overdue) due dates show higher.

- [x] Uncompleted tasks without a due date are ordered with most recent being placed higher (created_at and/or updated_at) (open to alternative ideas here also)

- [x] Completed tasks are ordered the same as above based on due date, or date created/edited.


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
[Screencast from 02-21-2024 07:46:34 AM.webm](https://github.com/rubyforgood/pet-rescue/assets/16829344/d10809e0-2a6b-4bf4-b7c7-1a619505e3c6)


