### PR TITLE
473 create page text

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,5 +22,5 @@ class Organization < ApplicationRecord
 
   has_one :profile, dependent: :destroy, class_name: "OrganizationProfile", required: true
   has_one :location, through: :profile
-  has_one :page_text
+  has_one :page_text, dependent: :destroy
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,4 +22,5 @@ class Organization < ApplicationRecord
 
   has_one :profile, dependent: :destroy, class_name: "OrganizationProfile", required: true
   has_one :location, through: :profile
+  has_one :page_text
 end

--- a/app/models/page_text.rb
+++ b/app/models/page_text.rb
@@ -19,4 +19,7 @@
 #
 class PageText < ApplicationRecord
   acts_as_tenant(:organization)
+
+  validates :hero, presence: true, allow_nil: true
+  validates :about, presence: true, allow_nil: true
 end

--- a/app/models/page_text.rb
+++ b/app/models/page_text.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: page_texts
+#
+#  id              :bigint           not null, primary key
+#  about           :text
+#  hero            :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_page_texts_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+class PageText < ApplicationRecord
+  acts_as_tenant(:organization)
+end

--- a/app/services/organizations/create_service.rb
+++ b/app/services/organizations/create_service.rb
@@ -39,6 +39,7 @@ class Organizations::CreateService
       create_staff_account
       add_admin_role_to_staff_account
       send_email
+      create_page_text
     end
   rescue => e
     raise "An error occurred: #{e.message}"
@@ -99,5 +100,11 @@ class Organizations::CreateService
       organization: @organization
     )
       .create_new_org_and_admin(@organization.slug).deliver_now
+  end
+
+  def create_page_text
+    ActsAsTenant.with_tenant(@organization) do
+      PageText.create!
+    end
   end
 end

--- a/db/migrate/20240225160909_create_page_texts.rb
+++ b/db/migrate/20240225160909_create_page_texts.rb
@@ -1,0 +1,11 @@
+class CreatePageTexts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :page_texts do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.string :hero
+      t.text :about
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_02_201249) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_25_160909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -187,6 +187,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_02_201249) do
     t.index ["slug"], name: "index_organizations_on_slug", unique: true
   end
 
+  create_table "page_texts", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.string "hero"
+    t.text "about"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_page_texts_on_organization_id"
+  end
+
   create_table "pets", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
@@ -290,6 +299,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_02_201249) do
   add_foreign_key "matches", "pets"
   add_foreign_key "organization_profiles", "locations"
   add_foreign_key "organization_profiles", "organizations"
+  add_foreign_key "page_texts", "organizations"
   add_foreign_key "pets", "organizations"
   add_foreign_key "staff_accounts", "organizations"
   add_foreign_key "staff_accounts", "users"

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -279,4 +279,6 @@ ActsAsTenant.with_tenant(@organization) do
   end
 
   @match.assign_checklist_template(@checklist_template)
+
+  PageText.create!(hero: nil, about: nil)
 end

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -279,4 +279,6 @@ ActsAsTenant.with_tenant(@organization) do
   end
 
   @match.assign_checklist_template(@checklist_template)
+
+  PageText.create!(hero: nil, about: nil)
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,10 +1,4 @@
 FactoryBot.define do
-  factory :page_text do
-    organization { nil }
-    hero { "MyString" }
-    about { "MyText" }
-  end
-
   factory :adopter_account do
     transient do
       organization { ActsAsTenant.current_tenant }
@@ -110,6 +104,12 @@ FactoryBot.define do
     phone_number { Faker::PhoneNumber.phone_number }
     about_us { Faker::Lorem.paragraph(sentence_count: 4) }
     location
+    organization { ActsAsTenant.current_tenant }
+  end
+
+  factory :page_text do
+    hero { "MyString" }
+    about { Faker::Lorem.sentence }
     organization { ActsAsTenant.current_tenant }
   end
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,4 +1,10 @@
 FactoryBot.define do
+  factory :page_text do
+    organization { nil }
+    hero { "MyString" }
+    about { "MyText" }
+  end
+
   factory :adopter_account do
     transient do
       organization { ActsAsTenant.current_tenant }

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -9,5 +9,6 @@ class OrganizationTest < ActiveSupport::TestCase
     should have_many(:pets)
 
     should have_one(:profile).dependent(:destroy).required
+    should have_one(:page_text).dependent(:destroy)
   end
 end

--- a/test/models/page_text_test.rb
+++ b/test/models/page_text_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class PageTextTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  context "validations" do
+    should validate_presence_of(:hero).allow_nil
+    should validate_presence_of(:about).allow_nil
+  end
 end

--- a/test/models/page_text_test.rb
+++ b/test/models/page_text_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PageTextTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/services/organizations/create_service_test.rb
+++ b/test/services/organizations/create_service_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Organizations::CreateServiceTest < ActiveSupport::TestCase
+  test "it creates page_text when organization is created" do
+    args = {
+      location: {
+        country: "Mexico",
+        city_town: "La Ventana",
+        province_state: "Baja"
+      },
+      organization: {
+        name: "Baja Pet Rescue",
+        slug: "baja"
+      },
+      user: {
+        email: "test@test.lol",
+        first_name: "Jimmy",
+        last_name: "Hendrix"
+      }
+    }
+
+    Organizations::CreateService.new.signal(args)
+    assert_not Organization.last.page_text.nil?
+  end
+end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

#473 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Adds a `PageText` model with `organization_id`, `about`, and `hero` columns, with index. `about` and `hero` allow nil but not empty strings or strings containing only whitespace. 

Updates create service object to create a page_text for organization, and seed files. 

Adds factory, tests for new model. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
