### PR TITLE
Remove delete account UI from reg/edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore bundler config.
 /.bundle
 
+# Ignore bundle folder in vendor
+/vendor/bundle/*
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -65,27 +65,6 @@
           </div> <!--col-->
         </div> <!--row-->
 
-        <!--cancel my account section-->
-        <div class="row mt-5">
-          <div class="col-md-6 mx-auto">
-            <h4 class="mb-2">Unhappy?</h4>
-            <p>Type 'goodbye' below then click the button to permanently delete your account.</p>
-
-            <div data-controller="delete">
-              <input type="text" data-action="input->delete#showButton"
-                    data-delete-target="input" class="form-control mt-2">
-
-              <%= button_to "Delete my account", registration_path(resource_name),
-                          class: 'btn custom-btn-pink mt-3 mb-3',
-                          data: { confirm: 'Are you sure?',
-                                  turbo: 'false',
-                                  delete_target: 'button' },
-                          method: 'delete',
-                          disabled: true %>
-            </div>
-          </div>
-        </div> <!--row-->
-
       </div><!--container-->
     </section>
   <% end %>


### PR DESCRIPTION
# 🔗 Issue
[issue 481](https://github.com/rubyforgood/pet-rescue/issues/481)

# ✍️ Description
Added line in git-ignore to ignore the bundle folder in the vendor folder. 
Removed code to delete account in reg/edit page, to include all UI elements.

# 📷 Screenshots/Demos
![ui-del-account-removed](https://github.com/rubyforgood/pet-rescue/assets/44660994/8874d9e4-97cd-49dc-9ca1-e49df6ec9236)

@all-contributors
please add @<username> for code. 
please add @<username> for review.
