### PR TITLE
Update Seeds for Org Profile Coutnry, State, Phone to fix issues

### DIFF
--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -1,6 +1,6 @@
 orga_location = Location.create!(
-  country: "USA",
-  province_state: "Nevada",
+  country: "US",
+  province_state: "NY",
   city_town: "AltaCity",
   zipcode: "12345"
 )
@@ -8,7 +8,7 @@ orga_location = Location.create!(
 @organization = Organization.create!(
   name: "Alta Pet Rescue",
   slug: "alta",
-  profile: OrganizationProfile.new(email: "alta@email.com", phone_number: "123 456 7890", location: orga_location, about_us: "We get pets into loving homes!")
+  profile: OrganizationProfile.new(email: "alta@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We get pets into loving homes!")
 )
 
 ActsAsTenant.with_tenant(@organization) do

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -1,6 +1,6 @@
 orga_location = Location.create!(
-  country: "USA",
-  province_state: "Nevada",
+  country: "US",
+  province_state: "NV",
   city_town: "BajaCity",
   zipcode: "12346"
 )
@@ -8,7 +8,7 @@ orga_location = Location.create!(
 @organization = Organization.create!(
   name: "Baja",
   slug: "baja",
-  profile: OrganizationProfile.new(email: "baja@email.com", phone_number: "123 456 7891", location: orga_location, about_us: "We help pets find their forever homes!")
+  profile: OrganizationProfile.new(email: "baja@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We help pets find their forever homes!")
 )
 
 ActsAsTenant.with_tenant(@organization) do


### PR DESCRIPTION
…y State gem so the value populates as expected in the form for Org profile edit. Also use a real phone number so it passes the phonelib gem validation on form save. The existing number was failing second validation.

# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Fixes the issue where the country and state are not pre-populated in the form selects on the Org Profile edit page. The reason was because we use the City State gem to load the select and the seed data needs to match the options provided by the gem. 

Also use an actual valid phone number in seeds to prevent the validation error when saving the form in the UI.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
