### PR TITLE
509 bug recurring pet task

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -24,7 +24,7 @@ class Organizations::TasksController < Organizations::BaseController
   end
 
   def update
-    @task.next_due_date_in_days = nil unless task_params.dig(:next_due_date_in_days)
+    @task.next_due_date_in_days = nil unless task_params.dig(:next_due_date_in_days) || task_params.dig(:completed)
 
     if @task.update(task_params)
       if @task.recurring && @task.completed_previously_changed?(from: false, to: true)

--- a/app/models/adopter_foster_profile.rb
+++ b/app/models/adopter_foster_profile.rb
@@ -42,8 +42,8 @@
 #
 # Indexes
 #
-#  index_adopter_profiles_on_adopter_account_id  (adopter_account_id)
-#  index_adopter_profiles_on_location_id         (location_id)
+#  index_adopter_foster_profiles_on_adopter_account_id  (adopter_account_id)
+#  index_adopter_foster_profiles_on_location_id         (location_id)
 #
 # Foreign Keys
 #

--- a/test/controllers/organizations/tasks_controller_test.rb
+++ b/test/controllers/organizations/tasks_controller_test.rb
@@ -135,8 +135,20 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     assert_turbo_stream action: "remove", target: @task
   end
 
-  test "should create a new task when recurring task is completed" do
+  test "should create a new task when recurring task without due date is completed" do
     task = create(:task, pet: @pet, recurring: true)
+
+    assert_difference "Task.count", 1 do
+      patch pet_task_path(@pet, task, format: :turbo_stream), params: {
+        task: {
+          completed: true
+        }
+      }
+    end
+  end
+
+  test "should create a new task when recurring task with due date is completed" do
+    task = create(:task, pet: @pet, recurring: true, due_date: Date.today + 2, next_due_date_in_days: 4)
 
     assert_difference "Task.count", 1 do
       patch pet_task_path(@pet, task, format: :turbo_stream), params: {

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -39,7 +39,7 @@ class TasksTest < ApplicationSystemTestCase
     assert has_current_path?(pet_path(@pet, active_tab: "tasks"))
   end
 
-  test "marking a recurring task as complete creates and displays a new task without redirecting" do
+  test "marking a recurring task without due date as complete creates and displays a new task without redirecting" do
     recurring_task = create(:task, recurring: true, pet: @pet, name: "recurring task")
 
     visit pet_path(@pet, active_tab: "tasks")
@@ -49,6 +49,20 @@ class TasksTest < ApplicationSystemTestCase
     end
 
     assert_text("recurring task", count: 2)
+    assert has_current_path?(pet_path(@pet, active_tab: "tasks"))
+  end
+
+  test "marking a recurring task with due date as complete creates and displays a new task without redirecting" do
+    due_date = (Date.today + 2.days)
+    recurring_task_with_due_date = create(:task, recurring: true, pet: @pet, name: "recurring task with due date", due_date: due_date, next_due_date_in_days: 4)
+
+    visit pet_path(@pet, active_tab: "tasks")
+
+    within("#edit_task_#{recurring_task_with_due_date.id}") do
+      check "task_completed"
+    end
+
+    assert_text("recurring task with due date", count: 2)
     assert has_current_path?(pet_path(@pet, active_tab: "tasks"))
   end
 


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

#509 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Fixes task#update action to not remove `next_due_in_days` value if the task is being marked complete. 

I added both a controller test and a system test, not sure if we really need both? Let me know and I can remove one if it's overkill. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
