### PR TITLE
Add a demo banner for public sites 🤏 

### DIFF
--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -101,3 +101,9 @@
     </div>
   </div>
 </nav>
+<!--  Demo banner-->
+<% if Rails.env.staging? %>
+  <div class="container-fluid m-0 p-2 text-center bg-danger-soft display-6">
+    This is a demo site
+  </div>
+<%  end %>


### PR DESCRIPTION
# ✍️ Description
Adding a demo banner to public testing site. This will make it clear to anyone accessing the site that it is just a demo and will prevent us from confusing prod/staging

# 📷 Screenshots/Demos
<img width="398" alt="Screen Shot 2024-03-09 at 2 30 21 PM" src="https://github.com/rubyforgood/pet-rescue/assets/34173394/9cbcb25d-5d0e-42b5-bddd-653ce84cea57">
