### PR TITLE
Refactor matches

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -10,20 +10,18 @@ class MatchesController < ApplicationController
     ))
 
     if @match.save
-      set_statuses_to_adoption_made
+      @match.retire_applications
+
       redirect_back_or_to dashboard_index_path, notice: "Pet successfully adopted."
     else
       redirect_back_or_to dashboard_index_path, alert: "Error."
     end
   end
 
-    @successful_application = @match.adopter_account
-      .adopter_applications
-      .where(pet_id: @match.pet_id)[0]
-    AdopterApplication.set_status_to_withdrawn(@successful_application)
-
   def destroy
     if @match.destroy
+      @match.withdraw_application
+
       redirect_to pets_path, notice: "Adoption reverted & application set to 'Withdrawn'"
     else
       redirect_to pets_path, alert: "Failed to revert adoption"
@@ -36,15 +34,6 @@ class MatchesController < ApplicationController
     params.permit(:pet_id, :adopter_account_id)
   end
 
-  # set status on all applications for a pet
-  def set_statuses_to_adoption_made
-    @applications = Pet.find(params[:pet_id]).adopter_applications
-    @applications.each do |app|
-      unless app.status == "withdrawn"
-        app.status = "adoption_made"
-        app.save
-      end
-    end
   def set_pet
     @pet = Pet.find(match_params[:pet_id])
   end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -43,7 +43,7 @@ class MatchesController < ApplicationController
   end
 
   def get_pet_id
-    return params[:pet_id] if params[:pet_id]
+    return match_params[:pet_id] if match_params[:pet_id]
 
     Match.find(params[:id]).pet_id
   end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,27 +1,28 @@
 class MatchesController < ApplicationController
   before_action :active_staff, :same_organization?
 
+  before_action :set_pet, only: %i[create]
+  before_action :set_match, only: %i[destroy]
+
   def create
-    @pet = Pet.find(adoption_params[:pet_id])
-    @match = Match.new(adoption_params.merge(organization_id: @pet.organization_id))
+    @match = Match.new(match_params.merge(
+      organization_id: @pet.organization_id
+    ))
 
     if @match.save
       set_statuses_to_adoption_made
       redirect_back_or_to dashboard_index_path, notice: "Pet successfully adopted."
     else
       redirect_back_or_to dashboard_index_path, alert: "Error."
-
     end
   end
-
-  def delete
-    @match = Match.find(params[:match_id])
 
     @successful_application = @match.adopter_account
       .adopter_applications
       .where(pet_id: @match.pet_id)[0]
     AdopterApplication.set_status_to_withdrawn(@successful_application)
 
+  def destroy
     if @match.destroy
       redirect_to pets_path, notice: "Adoption reverted & application set to 'Withdrawn'"
     else
@@ -31,8 +32,8 @@ class MatchesController < ApplicationController
 
   private
 
-  def adoption_params
-    params.permit(:pet_id, :adopter_account_id, :match_id)
+  def match_params
+    params.permit(:pet_id, :adopter_account_id)
   end
 
   # set status on all applications for a pet
@@ -44,12 +45,18 @@ class MatchesController < ApplicationController
         app.save
       end
     end
+  def set_pet
+    @pet = Pet.find(match_params[:pet_id])
+  end
+
+  def set_match
+    @match = Match.find(params[:id])
   end
 
   def get_pet_id
     return params[:pet_id] if params[:pet_id]
 
-    Match.find(params[:match_id]).pet_id
+    Match.find(params[:id]).pet_id
   end
 
   # staff and pet in the same org?

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -31,7 +31,7 @@ class MatchesController < ApplicationController
   private
 
   def match_params
-    params.permit(:pet_id, :adopter_account_id)
+    params.require(:match).permit(:pet_id, :adopter_account_id)
   end
 
   def set_pet

--- a/app/models/adopter_application.rb
+++ b/app/models/adopter_application.rb
@@ -53,14 +53,18 @@ class AdopterApplication < ApplicationRecord
     applications.any? { |app| app.profile_show == true }
   end
 
-  # set application status to withdrawn e.g. if reverting an adoption
-  def self.set_status_to_withdrawn(adopter_application)
-    adopter_application.status = :withdrawn
-    adopter_application.save
+  def self.retire_applications(pet_id:)
+    where(pet_id:).each do |adopter_application|
+      adopter_application.update!(status: :adoption_made)
+    end
   end
 
   def applicant_name
     "#{adopter_account.user.last_name}, #{adopter_account.user.first_name}"
+  end
+
+  def withdraw
+    update!(status: :withdrawn)
   end
 
   ransacker :applicant_name do

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -41,7 +41,7 @@ class Match < ApplicationRecord
   end
 
   def withdraw_application
-    adopter_application.withdraw
+    adopter_application&.withdraw
   end
 
   def retire_applications(application_class: AdopterApplication)

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -40,11 +40,23 @@ class Match < ApplicationRecord
     end
   end
 
+  def withdraw_application
+    adopter_application.withdraw
+  end
+
+  def retire_applications(application_class: AdopterApplication)
+    application_class.retire_applications(pet_id: pet_id)
+  end
+
   private
 
   def belongs_to_same_organization_as_pet
     if organization_id != pet.organization_id
       errors.add(:organization_id, :different_organization)
     end
+  end
+
+  def adopter_application
+    AdopterApplication.find_by(pet:, adopter_account:)
   end
 end

--- a/app/views/organizations/pets/tabs/partials/_application_status.html.erb
+++ b/app/views/organizations/pets/tabs/partials/_application_status.html.erb
@@ -29,7 +29,9 @@
     <% if app.status == 'successful_applicant' %>
       <!--create adoption button-->
       <%= button_to "New Adoption", matches_path, method: :post,
-        params: {pet_id: app.pet_id, adopter_account_id: app.adopter_account_id},
+        params: {match:
+          {pet_id: app.pet_id, adopter_account_id: app.adopter_account_id}
+        },
         class: "btn btn-outline-primary",
         data: { turbo_method: :post, 
                 turbo_confirm: "Click OK to finalize this adoption." 

--- a/app/views/organizations/pets/tabs/partials/_application_status.html.erb
+++ b/app/views/organizations/pets/tabs/partials/_application_status.html.erb
@@ -28,11 +28,13 @@
   <td class="align-middle text-center col-3">
     <% if app.status == 'successful_applicant' %>
       <!--create adoption button-->
-      <%= button_to "New Adoption", create_adoption_path(pet_id: app.pet.id, 
-                              dopter_account_id: app.adopter_account.id),
-                              class: "btn btn-outline-primary",
-                              data: { turbo_method: :post, 
-                                      turbo_confirm: "Click OK to finalize this adoption." } %>
+      <%= button_to "New Adoption", matches_path, method: :post,
+        params: {pet_id: app.pet_id, adopter_account_id: app.adopter_account_id},
+        class: "btn btn-outline-primary",
+        data: { turbo_method: :post, 
+                turbo_confirm: "Click OK to finalize this adoption." 
+        }
+      %>
     <% else %>
       <span class="d-inline-block" tabindex="0"
                 data-bs-toggle="tooltip" title="Finalize adoption">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,8 +54,7 @@ Rails.application.routes.draw do
   resources :adopter_applications, path: "applications",
     only: %i[index create update]
 
-  post "create_adoption", to: "matches#create"
-  delete "revoke_adoption", to: "matches#delete"
+  resources :matches, only: %i[create destroy]
 
   get "/contacts", to: "contacts#create"
   get "/contacts/new", to: "contacts#new", as: "new_contact"

--- a/test/integration/adopter_application_test.rb
+++ b/test/integration/adopter_application_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class AdopterApplicationTest < ActionDispatch::IntegrationTest
+class AdopterApplicationIntegrationTest < ActionDispatch::IntegrationTest
   setup do
     @organization = create(:organization)
     @pet_id = create(:pet, organization: @organization).id

--- a/test/models/adopter_application_test.rb
+++ b/test/models/adopter_application_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class AdopterApplicationTest < ActiveSupport::TestCase
+  setup do
+    @application = create(:adopter_application)
+  end
+
+  context "self.retire_applications" do
+    context "when some applications match pet_id and some do not" do
+      setup do
+        @selected_applications = Array.new(3) {
+          create(:adopter_application, pet_id: @application.pet_id)
+        }
+        @unselected_applications = Array.new(2) {
+          create(:adopter_application)
+        }
+      end
+
+      should "update status of matching applications to :adoption_made" do
+        AdopterApplication.retire_applications(pet_id: @application.pet_id)
+
+        @selected_applications.each do |application|
+          assert_equal "adoption_made", application.reload.status
+        end
+      end
+
+      should "not update status of mismatching applications" do
+        cached_statuses = @unselected_applications.map(&:status)
+
+        AdopterApplication.retire_applications(pet_id: @application.pet_id)
+
+        current_statuses = @unselected_applications.map do |application|
+          application.reload.status
+        end
+
+        assert_equal cached_statuses, current_statuses
+      end
+    end
+  end
+
+  context "#withdraw" do
+    should "update status to :withdrawn" do
+      @application.withdraw
+
+      assert "withdrawn", @application.status
+    end
+  end
+end

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -7,4 +7,33 @@ class MatchTest < ActiveSupport::TestCase
     should belong_to(:pet)
     should belong_to(:adopter_account)
   end
+
+  setup do
+    @match = build_stubbed(:match)
+  end
+
+  context "#withdraw_application" do
+    setup do
+      @application = mock("adopter_application")
+    end
+
+    should "send #withdraw to application" do
+      @match.expects(:adopter_application).returns(@application)
+      @application.expects(:withdraw)
+
+      @match.withdraw_application
+    end
+  end
+
+  context "#retire_applications" do
+    setup do
+      @application_class = mock("AdopterApplication")
+    end
+
+    should "send #retire_applications with pet_id to application_class" do
+      @application_class.expects(:retire_applications).with(pet_id: @match.pet_id)
+
+      @match.retire_applications(application_class: @application_class)
+    end
+  end
 end


### PR DESCRIPTION
# 🔗 Issue
No issue.
Similar to  #475, I thought `Match` could benefit from refactoring. Note that I will be cleaning it up further, getting rid of `same_organization?` and `get_pet_id` in the Authz PR too.

# ✍️ Description
This started with me changing the routes to the Rails convention. I personally found it a little confusing that sometimes we refer to adoptions as "adoptions" and sometimes as a "match". This PR tries to at least make it so that things using `Match` refer to it as a "match". This includes things like the strong params name.

The other portion of this PR works to get `AdopterApplication` logic out of `MatchesController`. I think this business logic belongs in the models. I also like setting withdraw for an individual object more as an instance method rather than as a class method like `self.set_status_to_withdrawn` was doing. Feels more intuitive.

## Using `update!`
One thing I would like to bring attention to and get opinions on, is that I opted to use `update!` instead of `update` for these new methods. I was of two minds on it. The main difference is that `update!` is not silent and will raise an error. That seems undesirable in some cases.

However, where would this failure occur? Currently, `retire_applications` is called in `AdopterApplication#create` after a valid creation is performed. If something was going wrong where the applications could not update following a successful match, I think we would want to know about that. I also think the use cases here are fairly reliable and can't think of a case where I would expect them to fail.

## Using mocks
I would also be curious of opinions on how I wrote the model tests too. I think mocking works well for some of those tests but would love to hear other's thoughts.