### PR TITLE
Fix adoptable_pet issue and add tests

### DIFF
--- a/app/controllers/adoptable_pets_controller.rb
+++ b/app/controllers/adoptable_pets_controller.rb
@@ -12,7 +12,7 @@ class AdoptablePetsController < Organizations::BaseController
       redirect_to adoptable_pets_path, alert: "You can only view published pets."
     end
 
-    if current_user
+    if current_user&.adopter_account
       @adoption_application =
         AdopterApplication.find_by(
           pet_id: @pet.id,

--- a/app/views/adoptable_pets/show.html.erb
+++ b/app/views/adoptable_pets/show.html.erb
@@ -18,7 +18,9 @@
           </div>
         </div>
         <div>
-          <%= link_to 'Become an adopter', new_user_registration_path, class: 'btn btn-primary btn-sm d-none d-md-block' %>
+          <% unless current_user %>
+            <%= link_to t('general.become_an_adopter'), new_user_registration_path, class: 'btn btn-primary btn-sm d-none d-md-block' %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/organizations/pets/tabs/partials/_application_status.html.erb
+++ b/app/views/organizations/pets/tabs/partials/_application_status.html.erb
@@ -45,9 +45,9 @@
   <td class="align-middle">
     <span>
       <% if params[:active_tab] == 'applications' || @applications_tab == true %>
-        <%= app.notes.truncate(10) %>
+        <%= app.notes&.truncate(10) %>
       <% else %>
-        <%= app.notes.truncate(30) %>
+        <%= app.notes&.truncate(30) %>
       <% end %>
     </span>
     <button type="button" class="btn btn-outline-primary border border-0" data-bs-toggle="modal" data-bs-target="#notesModal<%= app.id %>">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
     attach: "Attach"
     adoption_pending: "(Adoption Pending)"
     age: "Age"
+    become_an_adopter: "Become an adopter"
     breed: "Breed"
     application: "Application"
     sex: "Sex"

--- a/test/integration/adoptable_pet_show_test.rb
+++ b/test/integration/adoptable_pet_show_test.rb
@@ -1,37 +1,103 @@
 require "test_helper"
 
 class AdoptablePetShowTest < ActionDispatch::IntegrationTest
-  test "unauthenticated users see create account prompt and link" do
-    skip("while new ui is implemented")
-    # pet = create(:pet)
-
-    # get "/adoptable_pets/#{pet.id}"
+  setup do
+    @available_pet = create(:pet)
+    set_organization(@available_pet.organization)
+    @pet_in_draft = create(:pet, published: false)
+    @pet_pending_adoption = create(:pet, :adoption_pending)
+    @adopted_pet = create(:pet, :adopted)
+    @staff_user = create(:staff_account).user
+    @adopter_user = create(:adopter_account).user
+    create(:adopter_foster_profile, adopter_account: @adopter_user.adopter_account)
   end
 
-  test "adopter without a profile sees complete my profile prompt and link" do
-    skip("while new ui is implemented")
-    # pet = create(:pet)
-    # sign_in create(:user, :adopter_without_profile)
-
-    # get "/adoptable_pets/#{pet.id}"
-
-    # check_messages
-    # assert_select "h4", "Complete your profile to apply for this pet"
-    # assert_select "a", "Complete my profile"
+  teardown do
+    check_messages
+    :after_teardown
   end
 
-  test "adopter with a profile sees love this pooch question and apply button" do
-    skip("while new ui is implemented")
-    #   pet = create(:pet)
-    #   sign_in create(:user, :adopter_with_profile)
+  test "unauthenticated users can see an available pet" do
+    get adoptable_pet_path(@available_pet)
 
-    #   get "/adoptable_pets/#{pet.id}"
+    assert_response :success
+    assert_cannot_apply_to_adopt
+  end
 
-    #   check_messages
-    #   assert_select "h4", "In love with this pooch?"
-    #   assert_select "form" do
-    #     assert_select "button", "Apply to Adopt"
-    # end
+  test "unauthenticated users can see a pet with a pending adoption" do
+    get adoptable_pet_path(@pet_pending_adoption)
+
+    assert_response :success
+  end
+
+  test "unauthenticated users cannot see an unpublished pet" do
+    get adoptable_pet_path(@pet_in_draft)
+
+    assert_response :redirect
+  end
+
+  test "unauthenticated users cannot see an adopted pet" do
+    get adoptable_pet_path(@adopted_pet)
+
+    assert_response :redirect
+  end
+
+  test "staff can see an available pet" do
+    sign_in @staff_user
+    get adoptable_pet_path(@available_pet)
+
+    assert_response :success
+  end
+
+  test "staff can see a pet with a pending adoption" do
+    sign_in @staff_user
+    get adoptable_pet_path(@pet_pending_adoption)
+
+    assert_response :success
+    assert_cannot_apply_to_adopt
+  end
+
+  test "staff cannot see an unpublished pet" do
+    sign_in @staff_user
+    get adoptable_pet_path(@pet_in_draft)
+
+    assert_response :redirect
+  end
+
+  test "staff cannot see an adopted pet" do
+    sign_in @staff_user
+    get adoptable_pet_path(@adopted_pet)
+
+    assert_response :redirect
+  end
+
+  test "adopter can see and apply to an available pet" do
+    sign_in @adopter_user
+    get adoptable_pet_path(@available_pet)
+
+    assert_response :success
+    assert_can_apply_to_adopt
+  end
+
+  test "adopter can see a pet with a pending adoption" do
+    sign_in @adopter_user
+    get adoptable_pet_path(@pet_pending_adoption)
+
+    assert_response :success
+  end
+
+  test "adopter cannot see an unpublished pet" do
+    sign_in @adopter_user
+    get adoptable_pet_path(@pet_in_draft)
+
+    assert_response :redirect
+  end
+
+  test "adopter cannot see an adopted pet" do
+    sign_in @adopter_user
+    get adoptable_pet_path(@adopted_pet)
+
+    assert_response :redirect
   end
 
   test "adopter application sees application status" do
@@ -47,20 +113,6 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
     # assert_select "h4.me-2", "Application Awaiting Review"
   end
 
-  test "staff do not see an adopt button only log out button" do
-    skip("while new ui is implemented")
-    # pet = create(:pet)
-    # sign_in create(:user, :verified_staff)
-
-    # get "/adoptable_pets/#{pet.id}"
-
-    # check_messages
-    # assert_select "form" do
-    #   assert_select "button", "Log Out"
-    # end
-    # assert_select "form", count: 1
-  end
-
   test "pet name shows adoption pending if it has any applications with that status" do
     skip("while new ui is implemented")
     # pet = create(:pet, :adoption_pending)
@@ -71,27 +123,11 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
     # assert_select "h1", "#{pet.name} (Adoption Pending)"
   end
 
-  test "an adopted pet can't be shown as an adoptable pet" do
-    skip("while new ui is implemented")
-    # adopted_pet = create(:pet, :adopted)
-
-    # get "/adoptable_pets/#{adopted_pet.id}"
-
-    # assert_response :redirect
-    # follow_redirect!
-    # check_messages
-    # assert_equal "You can only view pets that need adoption.", flash[:alert]
+  def assert_can_apply_to_adopt
+    assert_select "input[type='submit']", value: "Apply to Adopt"
   end
 
-  test "a drafted pet can't be shown" do
-    skip("while new ui is implemented")
-    # drafted_pet = create(:pet, published: false)
-    #
-    # get "/adoptable_pets/#{drafted_pet.id}"
-    #
-    # assert_response :redirect
-    # follow_redirect!
-    # check_messages
-    # assert_equal "You can only view published pets.", flash[:alert]
+  def assert_cannot_apply_to_adopt
+    assert_select "input[type='submit']", value: "Apply to Adopt", count: 0
   end
 end

--- a/test/integration/adoptable_pets_index_test.rb
+++ b/test/integration/adoptable_pets_index_test.rb
@@ -2,25 +2,25 @@ require "test_helper"
 
 class AdoptablePetsIndexTest < ActionDispatch::IntegrationTest
   setup do
-    @match = create(:adopter_application, :adoption_pending)
-    @pet = @match.pet
-    set_organization(@pet.organization)
-    @pet_count = Pet.unadopted.published.count
+    @available_pet = create(:pet)
+    set_organization(@available_pet.organization)
+    @pet_in_draft = create(:pet, published: false)
+    @pet_pending_adoption = create(:pet, :adoption_pending)
+    @adopted_pet = create(:pet, :adopted)
+  end
+
+  teardown do
+    check_messages
   end
 
   test "unauthenticated user can access adoptable pets index" do
-    get "/#{@pet.organization.slug}/adoptable_pets"
-    check_messages
+    get adoptable_pets_path
+
     assert_select "h1", "Up for adoption"
-  end
-
-  test "all unadopted, published pets show on the pet_index page" do
-    get "/#{@pet.organization.slug}/adoptable_pets"
-    assert_select "img.card-img-top", {count: @pet_count}
-  end
-
-  test "pet name shows adoption pending if it has any applications with that status" do
-    get "/#{@pet.organization.slug}/adoptable_pets"
-    assert_select "#adoption-status", "Adoption Pending"
+    assert_response :success
+    assert_select "a[href$='adoptable_pets/#{@available_pet.id}']", 1
+    assert_select "a[href$='adoptable_pets/#{@pet_in_draft.id}']", 0
+    assert_select "a[href$='adoptable_pets/#{@pet_pending_adoption.id}']", 1
+    assert_select "a[href$='adoptable_pets/#{@adopted_pet.id}']", 0
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,6 @@ class ActiveSupport::TestCase
   end
 
   def check_messages
-    assert_response :success
     assert_not response.parsed_body.include?("translation_missing"), "Missing translations, ensure this text is included in en.yml"
   end
 


### PR DESCRIPTION
# 🔗 Issue
Fixes #522 

# ✍️ Description
Fixes linked issue and adds integration tests. 
Expectation is that the adoptable_pets views are consistent across users - except for applicants being able to see their own application status 

I don't know how to DRY up these tests - should this be a spec?
