### PR TITLE
Fix: create associated adopter account when user signs up with registrations/new form

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -30,8 +30,7 @@ class RegistrationsController < Devise::RegistrationsController
       :password,
       :signup_role,
       :tos_agreement,
-      adopter_account_attributes: [:user_id],
-      staff_account_attributes: [:user_id])
+      adopter_account_attributes: [:user_id])
   end
 
   def account_update_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
   has_one :staff_account, dependent: :destroy
   has_one :adopter_account, dependent: :destroy
 
-  accepts_nested_attributes_for :adopter_account, :staff_account
+  accepts_nested_attributes_for :adopter_account
 
   # get user accounts for staff in a given organization
   def self.organization_staff(org_id)

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -12,11 +12,16 @@
 <section class="pb-5" id="registration_new">
   <div class='container'>
     <div class="row">
-      <div class="col-md-6 mx-auto card p-5">
+      <div class="col-md-6 mx-auto card p-5">        
         <%= bootstrap_form_for(resource, as: resource_name,
                      url: registration_path(resource_name)) do |f| %>
 
           <%= render "devise/shared/error_messages", resource: resource %>
+
+          <%# adopter_account built in registrations controller #new %>
+          <%= f.fields_for :adopter_account do |fields| %>
+            <%= fields.hidden_field :user_id %>
+          <% end %>
 
           <div class="form-group mb-3 bigger">
             <%= f.email_field :email,


### PR DESCRIPTION

# 🔗 Issue
Fixes https://github.com/rubyforgood/pet-rescue/issues/526

# ✍️ Description
Only adopter users will be using the registrations/new form as staff and fosterers will be handled with invites. 
We build in instance of the associated adopter_account in the registrations controller #new override action but we were missing the nested attributes for adopter_account in the form. Now when a user signs up with this form, an associated adopter account is created.

I did toy with some callback on the User model to create the associated adopter account, but I didn't really consider it User domain logic per se, and keeping the logic on the registrations controller and view seems to be appropriate enough.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
