### PR TITLE
479 480 page text controller and edit form

### DIFF
--- a/app/controllers/organizations/base_controller.rb
+++ b/app/controllers/organizations/base_controller.rb
@@ -8,12 +8,4 @@
 
 class Organizations::BaseController < ApplicationController
   include OrganizationScopable
-
-  before_action :set_current_organization
-
-  private
-
-  def set_current_organization
-    Current.organization = current_user.organization
-  end
 end

--- a/app/controllers/organizations/base_controller.rb
+++ b/app/controllers/organizations/base_controller.rb
@@ -8,4 +8,12 @@
 
 class Organizations::BaseController < ApplicationController
   include OrganizationScopable
+
+  before_action :set_current_organization
+
+  private
+
+  def set_current_organization
+    Current.organization = current_user.organization
+  end
 end

--- a/app/controllers/organizations/page_texts_controller.rb
+++ b/app/controllers/organizations/page_texts_controller.rb
@@ -1,4 +1,5 @@
 class Organizations::PageTextsController < Organizations::BaseController
+  layout "dashboard"
   def edit
     @page_text = current_user.organization.page_text
   end
@@ -6,7 +7,7 @@ class Organizations::PageTextsController < Organizations::BaseController
   def update
     @page_text = current_user.organization.page_text
     if @page_text.update(page_text_params)
-      redirect_to dashboard_path, notice: "Page text updated successfully!"
+      redirect_to edit_page_text_path, notice: "Page text updated successfully!"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/organizations/page_texts_controller.rb
+++ b/app/controllers/organizations/page_texts_controller.rb
@@ -1,11 +1,10 @@
 class Organizations::PageTextsController < Organizations::BaseController
   layout "dashboard"
+  before_action :set_page_text, only: %i[edit update]
   def edit
-    @page_text = current_user.organization.page_text
   end
 
   def update
-    @page_text = current_user.organization.page_text
     if @page_text.update(page_text_params)
       redirect_to edit_page_text_path, notice: "Page text updated successfully!"
     else
@@ -17,5 +16,11 @@ class Organizations::PageTextsController < Organizations::BaseController
 
   def page_text_params
     params.require(:page_text).permit(:hero, :about)
+  end
+
+  def set_page_text
+    @page_text = current_user.organization.page_text
+
+    authorize! @page_text
   end
 end

--- a/app/controllers/organizations/page_texts_controller.rb
+++ b/app/controllers/organizations/page_texts_controller.rb
@@ -1,10 +1,10 @@
 class Organizations::PageTextsController < Organizations::BaseController
   def edit
-    @page_text = Current.organization.page_text
+    @page_text = current_user.organization.page_text
   end
 
   def update
-    @page_text = Current.organization.page_text
+    @page_text = current_user.organization.page_text
     if @page_text.update(page_text_params)
       redirect_to dashboard_path, notice: "Page text updated successfully!"
     else

--- a/app/controllers/organizations/page_texts_controller.rb
+++ b/app/controllers/organizations/page_texts_controller.rb
@@ -1,0 +1,20 @@
+class Organizations::PageTextsController < Organizations::BaseController
+  def edit
+    @page_text = Current.organization.page_text
+  end
+
+  def update
+    @page_text = Current.organization.page_text
+    if @page_text.update(page_text_params)
+      redirect_to dashboard_path, notice: "Page text updated successfully!"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def page_text_params
+    params.require(:page_text).permit(:hero, :about)
+  end
+end

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -49,6 +49,7 @@ module Authorizable
       activate_staff
       invite_staff
       manage_organization_profile
+      manage_page_text
       manage_staff
     ]
   ).freeze

--- a/app/policies/organizations/page_text_policy.rb
+++ b/app/policies/organizations/page_text_policy.rb
@@ -1,0 +1,8 @@
+class Organizations::PageTextPolicy < ApplicationPolicy
+  pre_check :verify_organization!
+  pre_check :verify_active_staff!
+
+  def manage?
+    permission?(:manage_page_text)
+  end
+end

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -54,6 +54,11 @@
           <% end %>
         </li>
         <li class="nav-item">
+          <%= active_link_to edit_page_text_path(@page_text), class: "nav-link" do %>
+            <i class="nav-icon fe fe-file-text me-2"></i> Page Text
+          <% end %>
+        </li>
+        <li class="nav-item">
           <%= active_link_to staff_index_path, class: "nav-link" do %>
             <i class="nav-icon fe fe-users me-2"></i> Staff
           <% end %>

--- a/app/views/organizations/home/index.html.erb
+++ b/app/views/organizations/home/index.html.erb
@@ -7,7 +7,7 @@
             <h1 class="display-2 fw-bold mb-1 text-primary "><%= Current.organization.name %></h1>
           </div>  
           <div class="d-flex justify-content-center ">
-            <p class="lead mb-4 text-black text-uppercase ">Where every paw finds a home</p>
+            <p class="lead mb-4 text-black text-uppercase "><%= Current.organization.page_text.hero || "Where every paw finds a home" %></p>
           </div>
           <div class="d-flex justify-content-center">
           <%= link_to '#', class: "btn btn-dark btn-lg rounded-1 me-2" do %>

--- a/app/views/organizations/home/index.html.erb
+++ b/app/views/organizations/home/index.html.erb
@@ -7,7 +7,7 @@
             <h1 class="display-2 fw-bold mb-1 text-primary "><%= Current.organization.name %></h1>
           </div>  
           <div class="d-flex justify-content-center ">
-            <p class="lead mb-4 text-black text-uppercase "><%= Current.organization.page_text.hero || "Where every paw finds a home" %></p>
+            <p class="lead mb-4 text-black"><%= Current.organization.page_text.hero || "Where every paw finds a home" %></p>
           </div>
           <div class="d-flex justify-content-center">
           <%= link_to '#', class: "btn btn-dark btn-lg rounded-1 me-2" do %>

--- a/app/views/organizations/home/index.html.erb
+++ b/app/views/organizations/home/index.html.erb
@@ -7,7 +7,7 @@
             <h1 class="display-2 fw-bold mb-1 text-primary "><%= Current.organization.name %></h1>
           </div>  
           <div class="d-flex justify-content-center ">
-            <p class="lead mb-4 text-black"><%= Current.organization.page_text.hero || "Where every paw finds a home" %></p>
+            <p class="lead mb-4 text-black"><%= Current.organization.page_text&.hero || "Where every paw finds a home" %></p>
           </div>
           <div class="d-flex justify-content-center">
           <%= link_to '#', class: "btn btn-dark btn-lg rounded-1 me-2" do %>
@@ -150,7 +150,7 @@
         </div>
         <div class="col-lg-4 px-4 order-last order-lg-0">
             <p class='justify bigger'>
-              <%= Current.organization.page_text.about || "#{Current.organization.name} was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations."%>
+              <%= Current.organization.page_text&.about || "#{Current.organization.name} was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations."%>
             </p>
             <p class='text-center'>
               <%= link_to 'Read More', about_us_path, class: 'custom-btn-green mt-5 mb-3' %>

--- a/app/views/organizations/home/index.html.erb
+++ b/app/views/organizations/home/index.html.erb
@@ -150,11 +150,7 @@
         </div>
         <div class="col-lg-4 px-4 order-last order-lg-0">
             <p class='justify bigger'>
-              <%=Current.organization.name %> was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations.
-            </p>
-            <br>
-            <p class='justify bigger'>
-              In January 2021 Baja Pet Rescue decided to refocus its efforts as a rescue organization only, while the spay/neuter effort is run by a different organization. Baja Pet Rescue is currently being run by founder Danielle Gee and a group of wonderful volunteers.
+              <%= Current.organization.page_text.about || "#{Current.organization.name} was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations."%>
             </p>
             <p class='text-center'>
               <%= link_to 'Read More', about_us_path, class: 'custom-btn-green mt-5 mb-3' %>

--- a/app/views/organizations/page_texts/_form.html.erb
+++ b/app/views/organizations/page_texts/_form.html.erb
@@ -19,7 +19,7 @@
             </div>
             <!-- About Us -->
             <div class="form-group">
-              <%= form.text_field :about, label: "About Us", placeholder: "About Us text", class: 'form-control' %>
+              <%= form.text_area :about, label: "About Us", placeholder: "About Us text", class: 'form-control' %>
             </div>
           </form>
         <% end %>

--- a/app/views/organizations/page_texts/_form.html.erb
+++ b/app/views/organizations/page_texts/_form.html.erb
@@ -2,34 +2,29 @@
   <div class='card-body'>
     <div class="d-lg-flex align-items-center justify-content-between">
       <h3 class="mb-1">Landing page details</h3>
-        <p class="text-muted mb-3" style="font-size: 12px;">Edit your landing page.<p>
+      <p class="text-muted mb-3" style="font-size: 12px;">Edit your landing page.
+      <p>
     </div>
-
-    <!-- Administrative details section -->
     <div class="row mt-3">
-      <!-- First Column -->
       <div class="col-lg-6">
         <%= form.fields_for :page_text do |page_text_form| %>
           <form class="mb-3">
             <!-- Hero Text -->
             <div class="form-group">
               <%= form.text_field :hero,
-                                       label: "Hero",
-                                       autofocus: true,
-                                       placeholder: "hero text",
-                                       class: 'form-control' %>
+                                  label: "Hero",
+                                  autofocus: true,
+                                  placeholder: "hero text",
+                                  class: 'form-control' %>
             </div>
-
             <!-- About Us -->
             <div class="form-group">
               <%= form.text_field :about, label: "About Us", placeholder: "About Us text", class: 'form-control' %>
             </div>
-
           </form>
         <% end %>
       </div>
     </div>
-
     <div class="row mt-3">
       <div class="col-lg-12">
         <%= form.submit 'Save page text', class: 'btn btn-primary' %>

--- a/app/views/organizations/page_texts/_form.html.erb
+++ b/app/views/organizations/page_texts/_form.html.erb
@@ -1,0 +1,41 @@
+<%= bootstrap_form_with model: page_text, :url => page_text_path(@page_text), method: :patch do |form| %>
+  <div class='card-body'>
+    <div class="d-lg-flex align-items-center justify-content-between">
+      <h3 class="mb-1">Landing page details</h3>
+        <p class="text-muted mb-3" style="font-size: 12px;">Edit your landing page.<p>
+    </div>
+
+    <!-- Administrative details section -->
+    <div class="row mt-3">
+      <!-- First Column -->
+      <div class="col-lg-6">
+        <%= form.fields_for :page_text do |page_text_form| %>
+          <form class="mb-3">
+            <!-- Hero Text -->
+            <div class="form-group">
+              <%= form.text_field :hero,
+                                       label: "Hero",
+                                       autofocus: true,
+                                       placeholder: "hero text",
+                                       class: 'form-control' %>
+            </div>
+
+            <!-- About Us -->
+            <div class="form-group">
+              <%= form.text_field :about, label: "About Us", placeholder: "About Us text", class: 'form-control' %>
+            </div>
+
+          </form>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="row mt-3">
+      <div class="col-lg-12">
+        <%= form.submit 'Save page text', class: 'btn btn-primary' %>
+        <%= link_to t('general.cancel'), :back, class: 'btn btn-outline-secondary' %>
+      </div>
+    </div>
+  </div> <!-- End of Card Body -->
+<% end %>
+

--- a/app/views/organizations/page_texts/edit.html.erb
+++ b/app/views/organizations/page_texts/edit.html.erb
@@ -1,0 +1,15 @@
+<% breadcrumb :page_text %>
+
+<%= render "components/dashboard/page" do |p| %>
+  <% p.header_title "Page Text" %>
+  <% p.header_subtitle "Edit your page" %>
+  <% p.content do %>
+    <section id="account_select">
+      <div>
+        <div>
+          <%= render "form", page_text: @page_text %>
+        </div>
+      </div>
+    </section>
+  <% end %>
+<% end %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -15,6 +15,10 @@ crumb :organization_profile do |organization|
   link "Edit Profile", edit_organization_profile_path(organization)
 end
 
+crumb :page_text do |page_text|
+  link "Edit Page Text", edit_page_text_path(page_text)
+end
+
 crumb :staff_index do
   link "Staff", staff_index_path
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   scope module: :organizations do
     resource :organization_profile, only: %i[edit update]
+    resource :page_text, only: [:edit, :update]
 
     resources :home, only: [:index]
     resources :pets do
@@ -22,7 +23,6 @@ Rails.application.routes.draw do
     resources :dashboard, only: [:index]
     resources :adoption_application_reviews, only: [:index, :edit, :update]
     resources :foster_application_reviews, only: [:index]
-    resources :page_texts, only: [:edit, :update]
     resources :staff do
       post "deactivate", to: "staff#deactivate"
       post "activate", to: "staff#activate"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     resources :dashboard, only: [:index]
     resources :adoption_application_reviews, only: [:index, :edit, :update]
     resources :foster_application_reviews, only: [:index]
+    resources :page_texts, only: [:edit, :update]
     resources :staff do
       post "deactivate", to: "staff#deactivate"
       post "activate", to: "staff#activate"

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -8,7 +8,8 @@ orga_location = Location.create!(
 @organization = Organization.create!(
   name: "Alta Pet Rescue",
   slug: "alta",
-  profile: OrganizationProfile.new(email: "alta@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We get pets into loving homes!")
+  profile: OrganizationProfile.new(email: "alta@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We get pets into loving homes!"),
+  page_text: PageText.new(hero: 'Where every paw finds a hom', about: "Alta was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations.")
 )
 
 ActsAsTenant.with_tenant(@organization) do
@@ -275,6 +276,4 @@ ActsAsTenant.with_tenant(@organization) do
       redo
     end
   end
-
-  PageText.create!(hero: nil, about: nil)
 end

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -9,7 +9,7 @@ orga_location = Location.create!(
   name: "Alta Pet Rescue",
   slug: "alta",
   profile: OrganizationProfile.new(email: "alta@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We get pets into loving homes!"),
-  page_text: PageText.new(hero: 'Where every paw finds a hom', about: "Alta was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations.")
+  page_text: PageText.new(hero: "Where every paw finds a hom", about: "Alta was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations.")
 )
 
 ActsAsTenant.with_tenant(@organization) do

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -9,7 +9,7 @@ orga_location = Location.create!(
   name: "Baja",
   slug: "baja",
   profile: OrganizationProfile.new(email: "baja@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We help pets find their forever homes!"),
-  page_text: PageText.new(hero: 'hero text', about: "about us text")
+  page_text: PageText.new(hero: "hero text", about: "about us text")
 )
 
 ActsAsTenant.with_tenant(@organization) do

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -8,7 +8,8 @@ orga_location = Location.create!(
 @organization = Organization.create!(
   name: "Baja",
   slug: "baja",
-  profile: OrganizationProfile.new(email: "baja@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We help pets find their forever homes!")
+  profile: OrganizationProfile.new(email: "baja@email.com", phone_number: "250 816 8212", location: orga_location, about_us: "We help pets find their forever homes!"),
+  page_text: PageText.new(hero: 'hero text', about: "about us text")
 )
 
 ActsAsTenant.with_tenant(@organization) do

--- a/test/controllers/organizations/page_texts_controller_test.rb
+++ b/test/controllers/organizations/page_texts_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Organizations::PageTextsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @org = ActsAsTenant.current_tenant
+    admin = create(:user, :staff_admin, organization: @org)
+    sign_in admin
+    @page_text = create(:page_text, organization: @org)
+  end
+
+  context "GET #edit" do
+    should "get edit page" do
+      get edit_page_text_path(@page_text)
+      assert_response :success
+    end
+  end
+
+  context "PATCH #update" do
+    should "update page text" do
+      patch page_text_path(@page_text), params: { page_text: { hero: "Super Dog", about: "canine caped crusader" } }
+      assert_redirected_to dashboard_path
+      @page_text.reload
+      assert_equal "Super Dog", @page_text.hero
+      assert_equal "canine caped crusader", @page_text.about
+    end
+  end
+end

--- a/test/controllers/organizations/page_texts_controller_test.rb
+++ b/test/controllers/organizations/page_texts_controller_test.rb
@@ -10,7 +10,7 @@ class Organizations::PageTextsControllerTest < ActionDispatch::IntegrationTest
 
   context "GET #edit" do
     should "get edit page" do
-      get edit_page_text_path(@page_text)
+      get edit_page_text_path
       assert_response :success
     end
   end
@@ -18,8 +18,9 @@ class Organizations::PageTextsControllerTest < ActionDispatch::IntegrationTest
   context "PATCH #update" do
     should "update page text" do
       patch page_text_path(@page_text), params: { page_text: { hero: "Super Dog", about: "canine caped crusader" } }
-      assert_redirected_to dashboard_path
-      @page_text.reload
+      assert_response :redirect
+      follow_redirect!
+      assert_response :success
       assert_equal "Super Dog", @page_text.hero
       assert_equal "canine caped crusader", @page_text.about
     end

--- a/test/controllers/organizations/page_texts_controller_test.rb
+++ b/test/controllers/organizations/page_texts_controller_test.rb
@@ -1,13 +1,41 @@
 require "test_helper"
+require "action_policy/test_helper"
 
 class Organizations::PageTextsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @org = ActsAsTenant.current_tenant
-    admin = create(:user, :staff_admin, organization: @org)
+    admin = create(:staff_admin, organization: @org)
     sign_in admin
     @page_text = create(:page_text, organization: @org)
   end
 
+  context "authorization" do
+    include ActionPolicy::TestHelper
+
+    context "#edit" do
+      should "be authorized" do
+        assert_authorized_to(
+          :manage?, @page_text, with: Organizations::PageTextPolicy
+        ) do
+          get edit_page_text_url(@page_text)
+        end
+      end
+    end
+
+    context "#update" do
+      setup do
+        @params = {page_text: {hero: "Super Dog", about: "canine caped crusader"}}
+      end
+
+      should "be authorized" do
+        assert_authorized_to(
+          :manage?, @page_text, with: Organizations::PageTextPolicy
+        ) do
+          patch page_text_url(@page_text), params: @params
+        end
+      end
+    end
+  end
   context "GET #edit" do
     should "get edit page" do
       get edit_page_text_path

--- a/test/controllers/organizations/page_texts_controller_test.rb
+++ b/test/controllers/organizations/page_texts_controller_test.rb
@@ -17,7 +17,7 @@ class Organizations::PageTextsControllerTest < ActionDispatch::IntegrationTest
 
   context "PATCH #update" do
     should "update page text" do
-      patch page_text_path(@page_text), params: { page_text: { hero: "Super Dog", about: "canine caped crusader" } }
+      patch page_text_path(@page_text), params: {page_text: {hero: "Super Dog", about: "canine caped crusader"}}
       assert_response :redirect
       follow_redirect!
       assert_response :success

--- a/test/policies/organizations/page_text_policy_test.rb
+++ b/test/policies/organizations/page_text_policy_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+# See https://actionpolicy.evilmartians.io/#/testing?id=testing-policies
+class Organizations::PageTextPolicyTest < ActiveSupport::TestCase
+  include PetRescue::PolicyAssertions
+
+  setup do
+    @organization = ActsAsTenant.current_tenant
+    @policy = -> {
+      Organizations::PageTextPolicy.new(Pet, user: @user,
+        organization: @organization)
+    }
+  end
+
+  context "#manage?" do
+    setup do
+      @action = -> { @policy.call.apply(:manage?) }
+    end
+
+    context "when user is nil" do
+      setup do
+        @user = nil
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is adopter" do
+      setup do
+        @user = create(:adopter)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is deactivated staff" do
+      setup do
+        @user = create(:staff, :deactivated)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is active staff" do
+      setup do
+        @user = create(:staff)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is staff admin" do
+      setup do
+        @user = create(:staff_admin)
+      end
+
+      should "return true" do
+        assert_equal @action.call, true
+      end
+    end
+  end
+
+  context "#edit?" do
+    should "be an alias to :manage?" do
+      assert_alias_rule @policy.call, :edit?, :manage?
+    end
+  end
+
+  context "#update?" do
+    should "be an alias to :manage?" do
+      assert_alias_rule @policy.call, :update?, :manage?
+    end
+  end
+end

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class HomePageTest < ApplicationSystemTestCase
   setup do
-    @user = create(:user, :activated_staff)
+    @user = create(:user)
     @organization = @user.organization
     set_organization(@organization)
   end

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -8,7 +8,8 @@ class HomePageTest < ApplicationSystemTestCase
   end
 
   test "renders custom hero and about text from PageText or default text" do
-    PageText.create(hero: "Super Pets for a good paws", about: "All about us")
+    # PageText.create(hero: "Super Pets for a good paws", about: "All about us")
+    patch page_text_path(@page_text), params: {page_text: {hero: "Super Dog", about: "canine caped crusader"}}
     visit home_index_path
     assert_text "Super Pets for a good paws"
     assert_text "All about us"

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -8,8 +8,7 @@ class HomePageTest < ApplicationSystemTestCase
   end
 
   test "renders custom hero and about text from PageText or default text" do
-    # PageText.create(hero: "Super Pets for a good paws", about: "All about us")
-    patch page_text_path(@page_text), params: {page_text: {hero: "Super Dog", about: "canine caped crusader"}}
+    PageText.create(hero: "Super Pets for a good paws", about: "All about us")
     visit home_index_path
     assert_text "Super Pets for a good paws"
     assert_text "All about us"

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -7,9 +7,10 @@ class HomePageTest < ApplicationSystemTestCase
     set_organization(@organization)
   end
 
-  test "renders custom hero text from PageText or default text" do
-    PageText.create(hero: "Super Pets for a good paws")
+  test "renders custom hero and about text from PageText or default text" do
+    PageText.create(hero: "Super Pets for a good paws", about: "All about us")
     visit home_index_path
     assert_text "Super Pets for a good paws"
+    assert_text "All about us"
   end
 end

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -1,0 +1,15 @@
+require "application_system_test_case"
+
+class HomePageTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:user, :activated_staff)
+    @organization = @user.organization
+    set_organization(@organization)
+  end
+
+  test "renders custom hero text from PageText or default text" do
+    PageText.create(hero: "Super Pets for a good paws")
+    visit home_index_path
+    assert_text "Super Pets for a good paws"
+  end
+end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -31,6 +31,6 @@ class UsersTest < ApplicationSystemTestCase
     refute has_button?("Sign out")
     expected_path = "/" + @organization.slug + "/home"
     assert has_current_path?(expected_path)
-    assert_text "WHERE EVERY PAW FINDS A HOME"
+    assert_text "Where every paw finds a home"
   end
 end


### PR DESCRIPTION
# 🔗 Issue
Resolves #479 #480 
# ✍️ Description
This PR adds ability for staff admin to update org page text.  
- Implemented edit and update actions to allow staff admins to modify the hero and about attributes. 
- Created corresponding views to allow staff to edit page text from dashboard along with tests for coverage. 
- Updated about section in the home page view to use attributes from PageText or existing default message.

# 📷 Screenshots/Demos
![pet_rescue-edit_page_text](https://github.com/rubyforgood/pet-rescue/assets/9318603/4003d9aa-2df1-46ac-aaae-6075bcf69380)

