### PR TITLE
548 navbar accessibility

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -9,3 +9,18 @@
 label.required:after {
   content: " *";
 }
+
+.aria-dropdown-menu {
+  display: block;
+  background-color: white;
+  border: none;
+  border-radius: 0.5rem;
+  box-shadow: var(--geeks-dropdown-shadow);
+  color: var(--geeks-gray-800);
+  font-size: 0.875rem;
+  line-height: 1.2rem;
+  margin: 1.125rem 0;
+  min-width: 12rem;
+  padding: 1rem 0;
+  top: 28px;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -10,6 +10,8 @@ label.required:after {
   content: " *";
 }
 
+// This class is intended to be used in conjunction with dropdown_controller.js
+// to avoid theme default dropdown behaviors (hover-open in desktop view).
 .aria-dropdown-menu {
   display: block;
   background-color: white;

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["menu"];
+
+  initialize() {
+    this.close();
+  }
+
+  toggle() {
+    this.menuTarget.hidden === true ? this.open() : this.close();
+  }
+
+  open() {
+    this.menuTarget.hidden = false;
+  }
+
+  close() {
+    this.menuTarget.hidden = true;
+  }
+}

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,5 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
+// Dropdown menu controller
+// Use only where theme dropdown menu defaults (hover-open) are undesirable.
 export default class extends Controller {
   static targets = ["button", "menu"];
 

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -5,6 +5,15 @@ export default class extends Controller {
 
   initialize() {
     this.close();
+    this.closeMenuOnOutsideClick = this.closeMenuOnOutsideClick.bind(this);
+  }
+
+  connect() {
+    window.addEventListener("click", this.closeMenuOnOutsideClick);
+  }
+
+  disconnect() {
+    window.removeEventListener("click", this.closeMenuOnOutsideClick);
   }
 
   toggle() {
@@ -21,5 +30,13 @@ export default class extends Controller {
     this.menuTarget.hidden = true;
     this.menuTarget.setAttribute("aria-hidden", "true");
     this.buttonTarget.setAttribute("aria-expanded", "false");
+  }
+
+  closeMenuOnOutsideClick(event) {
+    if (this.element === event.target || this.element.contains(event.target)) {
+      return;
+    }
+
+    this.close();
   }
 }

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["menu"];
+  static targets = ["button", "menu"];
 
   initialize() {
     this.close();
@@ -13,9 +13,13 @@ export default class extends Controller {
 
   open() {
     this.menuTarget.hidden = false;
+    this.menuTarget.setAttribute("aria-hidden", "false");
+    this.buttonTarget.setAttribute("aria-expanded", "true");
   }
 
   close() {
     this.menuTarget.hidden = true;
+    this.menuTarget.setAttribute("aria-hidden", "true");
+    this.buttonTarget.setAttribute("aria-expanded", "false");
   }
 }

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -73,7 +73,6 @@
         </div>
       </div>
     </div>
-    <!-- Button -->
 
     <!-- Collapse -->
     <div class="justify-content-end collapse navbar-collapse" id="navbar-default3">

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -26,6 +26,7 @@
           <% end %>
         </button>
 
+        <!-- Use "aria-dropdown-menu" here to avoid the theme's default hover-open behavior for accessibility concerns. -->
         <div class="aria-dropdown-menu position-absolute end-0" data-dropdown-target="menu" hidden aria-hidden="true" aria-labelledby="nav-dropdown-button" style='z-index: 1000'>
           <% if user_signed_in? %>
             <ul class="list-unstyled">

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -19,14 +19,14 @@
         <%= active_link_to 'Log In', new_user_session_path, class: 'btn btn-primary' %>
       <% end %>
 
-      <li class="dropdown ms-2 list-unstyled">
-        <a class="rounded-circle" href="#" role="button" id="dropdownUser" data-bs-toggle="dropdown" aria-expanded="false">
+      <div class="dropdown ms-2 list-unstyled position-relative" data-controller="dropdown">
+        <button class="btn p-0 border-0" data-action="dropdown#toggle" aria-expanded="false">
           <% if user_signed_in? %>
            <%= render_avatar_partial %>
           <% end %>
-        </a>
+        </button>
 
-        <div class="dropdown-menu dropdown-menu-end pb-0" aria-labelledby="dropdownUser" style='z-index: 1000'>
+        <div class="aria-dropdown-menu position-absolute end-0" data-dropdown-target="menu" hidden aria-labelledby="dropdownUser" style='z-index: 1000'>
           <% if user_signed_in? %>
             <ul class="list-unstyled">
               <% if current_user.adopter_account && current_user.adopter_account.adopter_foster_profile.nil? %>
@@ -71,12 +71,12 @@
             <% end %>
           <% end %>
         </div>
-      </li>
+      </div>
     </div>
     <!-- Button -->
 
     <!-- Collapse -->
-    <div class="justify-content-end collapse navbar-collapse " id="navbar-default3">
+    <div class="justify-content-end collapse navbar-collapse" id="navbar-default3">
       <ul class="navbar-nav">
 
         <li class='nav-item'>

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -20,13 +20,13 @@
       <% end %>
 
       <div class="dropdown ms-2 list-unstyled position-relative" data-controller="dropdown">
-        <button class="btn p-0 border-0" data-action="dropdown#toggle" aria-expanded="false">
+        <button class="btn p-0 border-0" id="nav-dropdown-button" data-action="dropdown#toggle" data-dropdown-target="button" aria-expanded="false">
           <% if user_signed_in? %>
            <%= render_avatar_partial %>
           <% end %>
         </button>
 
-        <div class="aria-dropdown-menu position-absolute end-0" data-dropdown-target="menu" hidden aria-labelledby="dropdownUser" style='z-index: 1000'>
+        <div class="aria-dropdown-menu position-absolute end-0" data-dropdown-target="menu" hidden aria-hidden="true" aria-labelledby="nav-dropdown-button" style='z-index: 1000'>
           <% if user_signed_in? %>
             <ul class="list-unstyled">
               <% if current_user.adopter_account && current_user.adopter_account.adopter_foster_profile.nil? %>

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -26,7 +26,7 @@
           <% end %>
         </button>
 
-        <!-- Use "aria-dropdown-menu" here to avoid the theme's default hover-open behavior for accessibility concerns. -->
+        <%# Use "aria-dropdown-menu" here to avoid the theme's default hover-open behavior for accessibility concerns. %>
         <div class="aria-dropdown-menu position-absolute end-0" data-dropdown-target="menu" hidden aria-hidden="true" aria-labelledby="nav-dropdown-button" style='z-index: 1000'>
           <% if user_signed_in? %>
             <ul class="list-unstyled">


### PR DESCRIPTION
# 🔗 Issue
#548 

# ✍️ Description
Note: Enthusiastic to hear cleaner, alternative approaches. I am not a fan of bootstrap and avoid it in my personal projects, so I may not be familiar with some better ways to overwrite some of this behavior.

This PR aims to make the navigation bar more accessibility friendly. Currently the right corner navbar on desktop view only shows if you hover the icon. This is terrible for keyboard users as it makes it potentially impossible for them to open it, and that's the only place where some of those links live!

This behavior is coming from media queries from the theme we are using. Some of the culprit rules are here:
```css
@media (min-width: 1200px) {
  .navbar .dropdown-menu {
    display: block;
    opacity: 0;
    transform: translateY(20px);
    transition: all 0.3s ease-in-out;
    visibility: hidden;
  }
  .navbar .dropdown-menu-end {
    left: auto;
    right: 0;
  }
  .navbar .dropdown-menu-start {
    left: 0;
    right: auto;
  }
  .navbar .dropdown-submenu:hover > .dropdown-menu,
  .navbar .dropdown:hover > .dropdown-menu {
    opacity: 1;
    transform: scaleY(1);
    visibility: visible;
  }
}

```

The first approach I tried was to just overwrite the CSS rules I found from the theme. However, that approach did not work because I don't think there is a way to overwrite the JavaScript that the theme is utilizing as well based off of the viewport widths.

What I opted for instead was to create our own custom class for the menu and also use a simple Stimulus controller to toggle/collapse the menu. 

What I do not like about this approach is the custom CSS. If we change the theme, we would have to update this CSS as well. I think the Stimulus controller is nice for our own control, but it may not fully mimic the behavior from BS.

Alternatives:
1. Instead of removing the theme classes and adding our own to the elements, we could keep the old theme classes, overwrite all the rules causing this behavior, and then also use our own JavaScript to enforce the toggling for the desktop view. Advantage to this approach is that we no longer need the custom css for our own class, but now we have custom css to overwrite all related rules. It may also be confusing having BS handling the JS for all the smaller viewports and then our own JS for the larger desktop one. We may have to enforce our own JS to only target the related elements for the desktop view too because the BS Javascript is going to still try to target them in the mobile view. That may cause some conflict.
2. Yuri on slack suggested reorganizing the HTML to try to avoid BS applying the theme's navbar behavior by taking the navbar menu button out of the "navbar":
```html
<nav>
  <div class="navbar"> Navbar Link etc </div>
  <div>Icon Stuff</div>
</nav>
```
I think I might like this approach better, but I also am not fully satisfied with it too. Potential issues with it I see are:
1. We may have to fight the navbar to get it to look the same as it currently does, as the BS theme isn't expecting the menu button to be outside of it. For example, the second mobile menu will need some adjustment.
2. If we end up wanting more dropdowns in the navbar for any reason, not placed at the edge, this could potentially get even more convoluted.
3. Having a BS theme dictate how our elements are semantically arranged feels bad.

Fun fact, I noticed this hover behavior of the navbar has a test using a 5 second hover wait built into the `test/system/user.rb` test. Once @kasugaijin refactors the navbars so we use this one in both places, this new, no-hover behavior means we can shave 5 seconds off our test suite! lol

# 📷 Screenshots/Demos
In this clip, the left side is the live site (main) and the right side is this branch.
https://github.com/rubyforgood/pet-rescue/assets/81536479/23e4683b-872e-47e9-b104-eff73a45e23d

