### PR TITLE
Fix organization contexts for policies

### DIFF
--- a/app/controllers/organizations/dashboard_controller.rb
+++ b/app/controllers/organizations/dashboard_controller.rb
@@ -3,7 +3,7 @@ class Organizations::DashboardController < Organizations::BaseController
 
   def index
     @user = current_user
-    @organization = @user.organization
+    @organization = Current.organization
     @hide_footer = true
 
     authorize! :dashboard, context: {organization: @organization}

--- a/app/controllers/organizations/invitations_controller.rb
+++ b/app/controllers/organizations/invitations_controller.rb
@@ -12,11 +12,11 @@ class Organizations::InvitationsController < Devise::InvitationsController
   end
 
   def create
+    authorize! StaffAccount, context: {organization: Current.organization},
+      with: Organizations::InvitationPolicy
+
     @user = User.new(user_params.merge(password: SecureRandom.hex(8)).except(:roles))
     @user.staff_account = StaffAccount.new
-
-    authorize! StaffAccount, context: {organization: @user.organization},
-      with: Organizations::InvitationPolicy
 
     if @user.save
       @user.add_role(user_params[:roles], Current.organization)


### PR DESCRIPTION
# 🔗 Issue
Related to #466 

# ✍️ Description
Fix a few organization contexts that should have been pointing to `Current.organization`.

This change avoids possible error raises from user not existing, and they should instead get unauthorized, redirected, and shown an authorization message.
