### PR TITLE
557 UI: Remove inapplicable content for adopted pet in Pet's summary

### DIFF
--- a/app/views/organizations/pets/tabs/_overview.html.erb
+++ b/app/views/organizations/pets/tabs/_overview.html.erb
@@ -14,49 +14,49 @@
           </div>
         </div>
       </div>
-
       <div class="card-body table-responsive">
-
         <table class="table">
           <div>
             <tr>
               <th>Sex</th>
-              <th>Breed</th> 
+              <th>Breed</th>
               <th>Weight</th>
-              <th>Placement Type</th>
-              <th>Application Status</th>
-              <th>Publish Status</th>
+              <% if @pet.match.nil? %>
+                <th>Placement Type</th>
+                <th>Application Status</th>
+                <th>Publish Status</th>
+              <% end %>
             </tr>
           </div>
-
           <tr>
             <td>
               <p class="text-dark mb-0 fw-semibold"><%= @pet.sex %></p>
             </td>
             <td>
               <p class="text-dark mb-0 fw-semibold"><%= @pet.breed %></p>
-            </td> 
+            </td>
             <td>
               <p class="text-dark mb-0 fw-semibold">
                 <%= "#{@pet.weight_from} - #{@pet.weight_to} #{@pet.weight_unit}" %>
               </p>
             </td>
-            <td>
-              <p class="text-dark mb-0 fw-semibold"><%= @pet.placement_type %></p>
-            </td>
-            <td>
-              <p class="text-dark mb-0 fw-semibold">
-                <%= @pet.application_paused == false ? t('.application.active') : t('.application.paused') %>
-              </p>
-            </td>
-            <td>
-              <p class="text-dark mb-0 fw-semibold">
-                <%= @pet.published == true ? t('.published.published') : t('.published.draft') %>
-              </p>
-            </td>
+            <% if @pet.match.nil? %>
+              <td>
+                <p class="text-dark mb-0 fw-semibold"><%= @pet.placement_type %></p>
+              </td>
+              <td>
+                <p class="text-dark mb-0 fw-semibold">
+                  <%= @pet.application_paused == false ? t('.application.active') : t('.application.paused') %>
+                </p>
+              </td>
+              <td>
+                <p class="text-dark mb-0 fw-semibold">
+                  <%= @pet.published == true ? t('.published.published') : t('.published.draft') %>
+                </p>
+              </td>
+            <% end %>
           </tr>
         </table>
-
         <p class="mt-5"><%= @pet.description %> </p>
       </div>
     </div>


### PR DESCRIPTION
Resolves #557 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Conditionally show/hide pet summary column's based on if the pet is adopted or not.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

Unadopted
![Screenshot from 2024-03-18 13-42-16](https://github.com/rubyforgood/pet-rescue/assets/16829344/fa470065-d7d0-4907-8fb3-5fd3bd16dc91)

Adopted
![Screenshot from 2024-03-18 13-42-03](https://github.com/rubyforgood/pet-rescue/assets/16829344/2f5fa26f-29a7-412d-981a-5e9e144a3fbf)


