### PR TITLE
555 adopter app validations

### DIFF
--- a/app/models/adopter_application.rb
+++ b/app/models/adopter_application.rb
@@ -32,6 +32,12 @@ class AdopterApplication < ApplicationRecord
     :successful_applicant,
     :adoption_made]
 
+  validates :adopter_foster_account,
+    uniqueness: {
+      scope: :pet,
+      message: "has already applied for this pet."
+    }
+
   # remove adoption_made status as not necessary for staff
   def self.app_review_statuses
     AdopterApplication.statuses.keys.map do |status|

--- a/app/models/adopter_application.rb
+++ b/app/models/adopter_application.rb
@@ -13,6 +13,7 @@
 #
 # Indexes
 #
+#  index_adopter_applications_on_account_and_pet            (pet_id,adopter_foster_account_id) UNIQUE
 #  index_adopter_applications_on_adopter_foster_account_id  (adopter_foster_account_id)
 #  index_adopter_applications_on_pet_id                     (pet_id)
 #

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -13,7 +13,7 @@
 #
 #  index_matches_on_adopter_foster_account_id  (adopter_foster_account_id)
 #  index_matches_on_organization_id            (organization_id)
-#  index_matches_on_pet_id                     (pet_id)
+#  index_matches_on_pet_id                     (pet_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -26,6 +26,7 @@ class Match < ApplicationRecord
   belongs_to :adopter_foster_account
 
   validate :belongs_to_same_organization_as_pet, if: -> { pet.present? }
+  validates :pet, uniqueness: true
 
   after_create_commit :send_reminder
 

--- a/db/migrate/20240321032816_change_index_in_matches_on_pet_id_to_unique.rb
+++ b/db/migrate/20240321032816_change_index_in_matches_on_pet_id_to_unique.rb
@@ -1,0 +1,6 @@
+class ChangeIndexInMatchesOnPetIdToUnique < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :matches, :pet_id
+    add_index :matches, :pet_id, unique: true
+  end
+end

--- a/db/migrate/20240322214921_index_adopter_applications_on_account_and_pet.rb
+++ b/db/migrate/20240322214921_index_adopter_applications_on_account_and_pet.rb
@@ -1,0 +1,7 @@
+class IndexAdopterApplicationsOnAccountAndPet < ActiveRecord::Migration[7.0]
+  def change
+    add_index :adopter_applications, [:pet_id, :adopter_foster_account_id],
+      unique: true,
+      name: "index_adopter_applications_on_account_and_pet"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -138,7 +138,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_22_214921) do
     t.bigint "organization_id", null: false
     t.index ["adopter_foster_account_id"], name: "index_matches_on_adopter_foster_account_id"
     t.index ["organization_id"], name: "index_matches_on_organization_id"
-    t.index ["pet_id"], name: "index_matches_on_pet_id"
+    t.index ["pet_id"], name: "index_matches_on_pet_id", unique: true
   end
 
   create_table "organization_profiles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_22_083755) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_22_214921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_22_083755) do
     t.text "notes"
     t.boolean "profile_show", default: true
     t.index ["adopter_foster_account_id"], name: "index_adopter_applications_on_adopter_foster_account_id"
+    t.index ["pet_id", "adopter_foster_account_id"], name: "index_adopter_applications_on_account_and_pet", unique: true
     t.index ["pet_id"], name: "index_adopter_applications_on_pet_id"
   end
 

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -261,13 +261,19 @@ ActsAsTenant.with_tenant(@organization) do
   )
 
   10.times do
-    AdopterApplication.create!(
+    adopter_application = AdopterApplication.new(
       notes: Faker::Lorem.paragraph,
       profile_show: true,
-      status: rand(0..5),
-      adopter_foster_account: AdopterFosterAccount.joins(:user).where(users: {organization_id: @organization.id}).sample,
+      status: rand(0..4),
+      adopter_foster_account: AdopterFosterAccount.all.sample,
       pet: Pet.all.sample
     )
+
+    if adopter_application.valid?
+      adopter_application.save!
+    else
+      redo
+    end
   end
 
   PageText.create!(hero: nil, about: nil)

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -261,13 +261,19 @@ ActsAsTenant.with_tenant(@organization) do
   )
 
   10.times do
-    AdopterApplication.create!(
+    adopter_application = AdopterApplication.new(
       notes: Faker::Lorem.paragraph,
       profile_show: true,
-      status: rand(0..5),
-      adopter_foster_account: AdopterFosterAccount.joins(:user).where(users: {organization_id: @organization.id}).sample,
+      status: rand(0..4),
+      adopter_foster_account: AdopterFosterAccount.all.sample,
       pet: Pet.all.sample
     )
+
+    if adopter_application.valid?
+      adopter_application.save!
+    else
+      redo
+    end
   end
 
   PageText.create!(hero: nil, about: nil)


### PR DESCRIPTION
# 🔗 Issue
#555 

# ✍️ Description
## Acceptance criteria:
> an adopter to can have more than one adoption applications but can only have 1 application per pet

Added validations to model and to schema so that the Rails app checks for uniqueness of this relationship.

> a pet can only have 1 match (multiple adopters cannot "adopt" the same pet)

Added uniqueness validation to model and schema for pets on matches.

I also updated the seed file, so that it will redo invalid adopter application sampling attempts.

I did not make any UI changes, as currently adopter applications disappear from the index view when an adoption is made.