### PR TITLE
554 - link_to Log In removed from navbar view

### DIFF
--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -94,9 +94,6 @@
         <li class="nav-item">
           <%= active_link_to 'Donate', donate_path, class: 'nav-link' %>
         </li>
-        <li class="nav-item d-block d-md-none">
-          <%= active_link_to 'Log In', new_user_session_path, class: 'nav-link' %>
-        </li>
       </ul>
     </div>
   </div>

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -94,7 +94,7 @@
         <li class="nav-item">
           <%= active_link_to 'Donate', donate_path, class: 'nav-link' %>
         </li>
-        <li class="nav-item d-block d-md-none">
+        <li class="nav-item d-block d-lg-none">
           <%= button_to 'Log Out', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'nav-link' %>
         </li>
       </ul>

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -94,6 +94,9 @@
         <li class="nav-item">
           <%= active_link_to 'Donate', donate_path, class: 'nav-link' %>
         </li>
+        <li class="nav-item">
+          <%= button_to 'Log Out', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'nav-link' %>
+        </li>
       </ul>
     </div>
   </div>

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -94,7 +94,7 @@
         <li class="nav-item">
           <%= active_link_to 'Donate', donate_path, class: 'nav-link' %>
         </li>
-        <li class="nav-item">
+        <li class="nav-item d-block d-md-none">
           <%= button_to 'Log Out', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'nav-link' %>
         </li>
       </ul>


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/544

# ✍️ Description
After log in, Log In button still appeared on dropdown menu, in mobile view.

# 📷 Screenshots/Demos
![obraz](https://github.com/rubyforgood/pet-rescue/assets/131488886/be9d0294-926b-4a1f-8fa9-3a8fffd7ca68)

![obraz](https://github.com/rubyforgood/pet-rescue/assets/131488886/73ece43f-642b-4134-8b91-2e2e2a7ac7a3)

