### PR TITLE
Removing chartkick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,9 +148,6 @@ group :test do
   gem "mocha"
 end
 
-# Add chartkick for charts generation
-gem "chartkick", "~> 5.0"
-
 # Adds location data for cities and states around the world
 gem "city-state", "~> 1.1.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    chartkick (5.0.3)
     city-state (1.1.0)
       rubyzip (>= 2.3)
     coderay (1.1.3)
@@ -493,7 +492,6 @@ DEPENDENCIES
   bootstrap_form (~> 5.3)
   brakeman
   capybara
-  chartkick (~> 5.0)
   city-state (~> 1.1.0)
   cuprite
   dartsass-rails


### PR DESCRIPTION
### ✍️ Description
[chartkick](https://github.com/ankane/chartkick) was being used to generate charts in the previous version of this app. We aren't currently using this but will revisit later
