### PR TITLE
fix: made pet image bound

### DIFF
--- a/app/views/adopter_applications/index.html.erb
+++ b/app/views/adopter_applications/index.html.erb
@@ -21,7 +21,7 @@
                         align-items-center">
               <% if app.pet.images.attached? %>
                 <%= link_to adoptable_pet_path(app.pet.id) do %>
-                  <%= image_tag app.pet.images.first, class: 'app-img rounded' %>
+                  <%= image_tag app.pet.images.first, class: 'app-img rounded card-img-top' %>
                 <% end %>
               <% else %>
                 <%= link_to adoptable_pet_path(app.pet.id) do %>


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/543

# ✍️ Description
Fixed : In the "My Applications" view for an adopter - The pet image is not bound and can take up the whole screen.

# 📷 Screenshots/Demos

<img width="1406" alt="Screenshot 2024-03-25 at 9 58 38 AM" src="https://github.com/rubyforgood/pet-rescue/assets/61897123/7c488703-c794-443d-b455-277e38f172fa">
