### PR TITLE
600 assign roles

### DIFF
--- a/app/controllers/organizations/invitations_controller.rb
+++ b/app/controllers/organizations/invitations_controller.rb
@@ -15,11 +15,13 @@ class Organizations::InvitationsController < Devise::InvitationsController
     authorize! StaffAccount, context: {organization: Current.organization},
       with: Organizations::InvitationPolicy
 
-    @user = User.new(user_params.merge(password: SecureRandom.hex(8)).except(:roles))
+    @user = User.new(
+      user_params.merge(password: SecureRandom.hex(8)).except(:roles)
+    )
+    @user.add_role(user_params[:roles], Current.organization)
     @user.staff_account = StaffAccount.new
 
     if @user.save
-      @user.add_role(user_params[:roles], Current.organization)
       @user.invite!(current_user)
       redirect_to staff_index_path, notice: "Invite sent!"
     else

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -12,6 +12,14 @@ class RegistrationsController < Devise::RegistrationsController
     respond_with resource
   end
 
+  def create
+    super do |resource|
+      if resource.persisted?
+        resource.add_role(:adopter, Current.organization)
+      end
+    end
+  end
+
   private
 
   def set_layout

--- a/test/controllers/organizations/invitations_controller_test.rb
+++ b/test/controllers/organizations/invitations_controller_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "action_policy/test_helper"
 
-class Organizations::InvitationControllerTest < ActionDispatch::IntegrationTest
+class Organizations::InvitationsControllerTest < ActionDispatch::IntegrationTest
   context "#create" do
     setup do
       user = create(:staff_admin)

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,6 +1,17 @@
 require "test_helper"
 
 class RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  test "should assign adopter role when user is persisted" do
+    registration_params = {user: attributes_for(:user)}
+
+    post user_registration_url, params: registration_params
+
+    persisted_user = User.find_by(email: registration_params[:user][:email])
+    has_role = persisted_user.has_role?(:adopter, ActsAsTenant.current_tenant)
+
+    assert_equal has_role, true
+  end
+
   test "should get new with dashboard layout when signed in as staff" do
     user = create(:staff)
     organization = user.staff_account.organization


### PR DESCRIPTION
# 🔗 Issue
#600 

# ✍️ Description
This implements assigning the role of `:adopter` to `Users` when they register as an adopter. Currently, users who sign up for an account do not get this assignment, and thus do not have adopter permissions to navigate the site.

It also adds tests for this behavior, as well as for the existing assignment of the `:staff` and `:admin` roles from the invitations.

This does not implement the assignment of the `:fosterer` role as that role has not been added yet, and we also have not created the workflow for staff inviting fosterers yet.

I think we should leave the issue open for now to remember that we need to do this for fosterers. I've marked the tasks related to this PR as completed in the issue.

Some small naming/typo fixes are also included.