### PR TITLE
Create adopter applications scope to organization and ensures no dupl…

### DIFF
--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -265,9 +265,14 @@ ActsAsTenant.with_tenant(@organization) do
       notes: Faker::Lorem.paragraph,
       profile_show: true,
       status: rand(0..4),
-      adopter_foster_account: AdopterFosterAccount.all.sample,
-      pet: Pet.all.sample
+      adopter_foster_account: AdopterFosterAccount.joins(:user).where(users: { organization_id: @organization.id }).sample,
+      pet: Pet.where(organization_id: @organization.id).sample
     )
+
+    unless AdopterApplication.where(pet_id: adopter_application.pet_id,
+                                    adopter_foster_account_id: adopter_application.adopter_foster_account_id).empty?
+      redo
+    end
 
     if adopter_application.valid?
       adopter_application.save!

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -265,9 +265,14 @@ ActsAsTenant.with_tenant(@organization) do
       notes: Faker::Lorem.paragraph,
       profile_show: true,
       status: rand(0..4),
-      adopter_foster_account: AdopterFosterAccount.all.sample,
-      pet: Pet.all.sample
+      adopter_foster_account: AdopterFosterAccount.joins(:user).where(users: { organization_id: @organization.id }).sample,
+      pet: Pet.where(organization_id: @organization.id).sample
     )
+
+    unless AdopterApplication.where(pet_id: adopter_application.pet_id,
+                                    adopter_foster_account_id: adopter_application.adopter_foster_account_id).empty?
+      redo
+    end
 
     if adopter_application.valid?
       adopter_application.save!


### PR DESCRIPTION

# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
Seed data was creating adopter apps that were on pets or for adopter foster accounts in different orgs. This was causing errors, and obviously not desirable. This fixes to scope them to org and ensure no duplicate apps.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
