### PR TITLE
Adjust registration and session links in navbar (#601)

### DIFF
--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -16,6 +16,7 @@
       </div>
 
       <% unless user_signed_in? %>
+        <%= active_link_to 'Sign Up', new_user_registration_path, class: 'btn btn-primary mx-2' %>
         <%= active_link_to 'Log In', new_user_session_path, class: 'btn btn-primary' %>
       <% end %>
 
@@ -94,9 +95,11 @@
         <li class="nav-item">
           <%= active_link_to 'Donate', donate_path, class: 'nav-link' %>
         </li>
-        <li class="nav-item d-block d-lg-none">
-          <%= button_to 'Log Out', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'nav-link' %>
-        </li>
+        <% if user_signed_in? %>
+          <li class="nav-item d-block d-lg-none">
+            <%= button_to 'Log Out', destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'nav-link' %>
+          </li>
+        <% end %>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
# 🔗 Issue
[Adjust registration and session links in navbar](https://github.com/rubyforgood/pet-rescue/issues/601)

# ✍️ Description
Added Conditions to display actions when expected. Display logout when user signed in & and link signup in Nav bar.

# 📷 Screenshots/Demos
Fix for Exhibit 1 & 3
![Screenshot from 2024-04-05 22-28-44](https://github.com/rubyforgood/pet-rescue/assets/39021904/b35d34f9-f3ae-422d-b8d5-2251eb288231)
![Screenshot from 2024-04-05 22-37-52](https://github.com/rubyforgood/pet-rescue/assets/39021904/91c4edcb-4d62-4c59-9e3b-273f8c458e12)


Fix for Exhibit 2
![Screenshot from 2024-04-05 22-30-00](https://github.com/rubyforgood/pet-rescue/assets/39021904/dc8b2948-2176-4d79-9b50-a0728eb46fa0)

