### PR TITLE
599 add fosterer role

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -8,6 +8,7 @@ ADOPTER_PERMISSIONS = %i[
 ].freeze
 
 FOSTERER_PERMISSIONS = %i[
+  view_adopter_foster_dashboard
   create_adopter_foster_profiles
   manage_adopter_foster_profiles
 ].freeze

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -7,6 +7,11 @@ ADOPTER_PERMISSIONS = %i[
   manage_adopter_foster_profiles
 ].freeze
 
+FOSTERER_PERMISSIONS = %i[
+  create_adopter_foster_profiles
+  manage_adopter_foster_profiles
+].freeze
+
 STAFF_PERMISSIONS = (
   ADOPTER_PERMISSIONS.excluding(
     %i[
@@ -39,6 +44,7 @@ ADMIN_PERMISSIONS = (
 
 PERMISSIONS = {
   adopter: ADOPTER_PERMISSIONS,
+  fosterer: FOSTERER_PERMISSIONS,
   staff: STAFF_PERMISSIONS,
   admin: ADMIN_PERMISSIONS
 }.freeze

--- a/test/factories/adopter_foster_accounts.rb
+++ b/test/factories/adopter_foster_accounts.rb
@@ -1,15 +1,11 @@
 FactoryBot.define do
   factory :adopter_foster_account do
-    user { association :user }
+    user { association :adopter }
 
     trait :with_profile do
       adopter_foster_profile do
         association :adopter_foster_profile, adopter_foster_account: instance
       end
-    end
-
-    after(:build) do |_account, context|
-      context.user.add_role(:adopter, context.user.organization)
     end
   end
 end

--- a/test/factories/staff_accounts.rb
+++ b/test/factories/staff_accounts.rb
@@ -1,20 +1,10 @@
 FactoryBot.define do
   factory :staff_account do
-    user { association :user }
+    user { association :staff }
     deactivated_at { nil }
 
     trait :deactivated do
       deactivated_at { DateTime.now }
-    end
-
-    trait :admin do
-      after(:build) do |_account, context|
-        context.user.add_role(:admin, context.organization)
-      end
-    end
-
-    after(:build) do |_account, context|
-      context.user.add_role(:staff, context.organization)
     end
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -23,6 +23,22 @@ FactoryBot.define do
       end
     end
 
+    factory :fosterer do
+      adopter_foster_account do
+        association :adopter_foster_account, user: instance
+      end
+
+      trait :with_profile do
+        adopter_foster_account do
+          association :adopter_foster_account, :with_profile, user: instance
+        end
+      end
+
+      after(:build) do |user, _context|
+        user.add_role(:fosterer, user.organization)
+      end
+    end
+
     factory :staff do
       staff_account do
         association :staff_account, user: instance

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
           association :adopter_foster_account, :with_profile, user: instance
         end
       end
+
+      after(:build) do |user, _context|
+        user.add_role(:adopter, user.organization)
+      end
     end
 
     factory :staff do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -49,11 +49,20 @@ FactoryBot.define do
           association :staff_account, :deactivated, user: instance
         end
       end
+
+      after(:build) do |user, _context|
+        user.add_role(:staff, user.organization)
+      end
     end
 
     factory :staff_admin do
       staff_account do
-        association :staff_account, :admin, user: instance
+        association :staff_account, user: instance
+      end
+
+      after(:build) do |user, _context|
+        user.add_role(:staff, user.organization)
+        user.add_role(:admin, user.organization)
       end
     end
   end

--- a/test/integration/adoptable_pet_show_test.rb
+++ b/test/integration/adoptable_pet_show_test.rb
@@ -43,7 +43,7 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
 
   context "staff" do
     setup do
-      sign_in create(:staff_account).user
+      sign_in create(:staff)
     end
 
     should "see an available pet" do

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -23,8 +23,7 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
 
   context "active staff" do
     setup do
-      @staff_account = create(:staff_account)
-      sign_in @staff_account.user
+      sign_in create(:staff)
     end
 
     should "see all applications" do

--- a/test/policies/adopter_application_policy_test.rb
+++ b/test/policies/adopter_application_policy_test.rb
@@ -96,6 +96,16 @@ class AdopterApplicationPolicyTest < ActiveSupport::TestCase
         assert_equal @action.call, true
       end
     end
+
+    context "when user is fosterer with profile" do
+      setup do
+        @user = create(:fosterer, :with_profile)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
   end
 
   context "#create?" do
@@ -176,6 +186,16 @@ class AdopterApplicationPolicyTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context "when user is fosterer with profile" do
+      setup do
+        @user = create(:fosterer, :with_profile)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
   end
 
   context "existing record action" do
@@ -205,6 +225,16 @@ class AdopterApplicationPolicyTest < ActiveSupport::TestCase
         context "when user is adopter" do
           setup do
             @user = create(:adopter)
+          end
+
+          should "return false" do
+            assert_equal @action.call, false
+          end
+        end
+
+        context "when user is fosterer" do
+          setup do
+            @user = create(:fosterer)
           end
 
           should "return false" do

--- a/test/policies/attachment_policy_test.rb
+++ b/test/policies/attachment_policy_test.rb
@@ -36,6 +36,16 @@ class ActiveStorage::AttachmentPolicyTest < ActiveSupport::TestCase
         end
       end
 
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
       context "when user is active staff" do
         setup do
           @user = create(:staff)

--- a/test/policies/organizations/adoptable_pet_policy_test.rb
+++ b/test/policies/organizations/adoptable_pet_policy_test.rb
@@ -54,6 +54,16 @@ class Organizations::AdoptablePetPolicyTest < ActiveSupport::TestCase
         end
       end
 
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
       context "when user is staff" do
         setup do
           @user = create(:staff)
@@ -82,9 +92,36 @@ class Organizations::AdoptablePetPolicyTest < ActiveSupport::TestCase
         @user = create(:adopter, :with_profile)
       end
 
-      should "return false" do
-        assert_equal @action.call, false
+      context "when user is nil" do
+        setup do
+          @user = nil
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
       end
+
+      context "when user is adopter" do
+        setup do
+          @user = create(:adopter)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
     end
   end
 end

--- a/test/policies/organizations/adoptable_pet_policy_test.rb
+++ b/test/policies/organizations/adoptable_pet_policy_test.rb
@@ -122,6 +122,25 @@ class Organizations::AdoptablePetPolicyTest < ActiveSupport::TestCase
         end
       end
 
+      context "when user is staff" do
+        setup do
+          @user = create(:staff)
+        end
+
+        should "return true" do
+          assert_equal @action.call, true
+        end
+      end
+
+      context "when user is admin" do
+        setup do
+          @user = create(:staff_admin)
+        end
+
+        should "return true" do
+          assert_equal @action.call, true
+        end
+      end
     end
   end
 end

--- a/test/policies/organizations/adopter_application_policy_test.rb
+++ b/test/policies/organizations/adopter_application_policy_test.rb
@@ -39,6 +39,16 @@ class Organizations::AdopterApplicationPolicyTest < ActiveSupport::TestCase
         end
       end
 
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
       context "when user is activated staff" do
         setup do
           @user = create(:staff)
@@ -129,6 +139,16 @@ class Organizations::AdopterApplicationPolicyTest < ActiveSupport::TestCase
       context "when user is adopter" do
         setup do
           @user = create(:adopter)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
         end
 
         should "return false" do

--- a/test/policies/organizations/adopter_foster_profile_policy_test.rb
+++ b/test/policies/organizations/adopter_foster_profile_policy_test.rb
@@ -50,6 +50,26 @@ class Organizations::AdopterFosterProfilePolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer without profile" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return true" do
+        assert_equal @action.call, true
+      end
+    end
+
+    context "when user is fosterer with profile" do
+      setup do
+        @user = create(:fosterer, :with_profile)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is staff" do
       setup do
         @user = create(:staff)
@@ -105,6 +125,38 @@ class Organizations::AdopterFosterProfilePolicyTest < ActiveSupport::TestCase
       context "when user is adopter with profile" do
         setup do
           @user = create(:adopter, :with_profile)
+        end
+
+        context "when profile does not belong to user" do
+          should "return false" do
+            assert_equal @action.call, false
+          end
+        end
+
+        context "when profile belongs to user" do
+          setup do
+            @user = @profile.adopter_foster_account.user
+          end
+
+          should "return true" do
+            assert_equal @action.call, true
+          end
+        end
+      end
+
+      context "when user is fosterer without profile" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
+      context "when user is fosterer with profile" do
+        setup do
+          @user = create(:fosterer, :with_profile)
         end
 
         context "when profile does not belong to user" do

--- a/test/policies/organizations/dashboard_policy_test.rb
+++ b/test/policies/organizations/dashboard_policy_test.rb
@@ -39,6 +39,16 @@ class Organizations::DashboardPolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is deactivated staff" do
       setup do
         @user = create(:staff, :deactivated)

--- a/test/policies/organizations/default_pet_task_policy_test.rb
+++ b/test/policies/organizations/default_pet_task_policy_test.rb
@@ -38,6 +38,16 @@ class Organizations::DefaultPetTaskPolicyTest < ActiveSupport::TestCase
         end
       end
 
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
       context "when user is activated staff" do
         setup do
           @user = create(:staff)
@@ -138,6 +148,16 @@ class Organizations::DefaultPetTaskPolicyTest < ActiveSupport::TestCase
       context "when user is adopter" do
         setup do
           @user = create(:adopter)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
         end
 
         should "return false" do

--- a/test/policies/organizations/invitation_policy_test.rb
+++ b/test/policies/organizations/invitation_policy_test.rb
@@ -44,6 +44,16 @@ class Organizations::InvitationPolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is active staff" do
       setup do
         @user = create(:staff)

--- a/test/policies/organizations/match_policy_test.rb
+++ b/test/policies/organizations/match_policy_test.rb
@@ -34,6 +34,16 @@ class Organizations::MatchPolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is activated staff" do
       setup do
         @user = create(:staff)
@@ -111,6 +121,16 @@ class Organizations::MatchPolicyTest < ActiveSupport::TestCase
     context "when user is adopter" do
       setup do
         @user = create(:adopter)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
       end
 
       should "return false" do

--- a/test/policies/organizations/organization_profile_policy_test.rb
+++ b/test/policies/organizations/organization_profile_policy_test.rb
@@ -37,6 +37,16 @@ class Organizations::OrganizationProfilePolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is deactivated staff" do
       setup do
         @user = create(:staff, :deactivated)

--- a/test/policies/organizations/page_text_policy_test.rb
+++ b/test/policies/organizations/page_text_policy_test.rb
@@ -37,6 +37,16 @@ class Organizations::PageTextPolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is deactivated staff" do
       setup do
         @user = create(:staff, :deactivated)

--- a/test/policies/organizations/pet_policy_test.rb
+++ b/test/policies/organizations/pet_policy_test.rb
@@ -38,6 +38,16 @@ class Organizations::PetPolicyTest < ActiveSupport::TestCase
         end
       end
 
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
       context "when user is deactivated staff" do
         setup do
           @user = create(:staff, :deactivated)
@@ -112,6 +122,16 @@ class Organizations::PetPolicyTest < ActiveSupport::TestCase
       context "when user is adopter" do
         setup do
           @user = create(:adopter)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
         end
 
         should "return false" do

--- a/test/policies/organizations/profile_review_policy_test.rb
+++ b/test/policies/organizations/profile_review_policy_test.rb
@@ -38,6 +38,16 @@ class Organizations::ProfileReviewPolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is activated staff" do
       setup do
         @user = create(:staff)

--- a/test/policies/organizations/staff_account_policy_test.rb
+++ b/test/policies/organizations/staff_account_policy_test.rb
@@ -34,6 +34,16 @@ class Organizations::StaffAccountPolicyTest < ActiveSupport::TestCase
       end
     end
 
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
     context "when user is staff" do
       setup do
         @user = create(:staff)
@@ -83,6 +93,16 @@ class Organizations::StaffAccountPolicyTest < ActiveSupport::TestCase
     context "when user is adopter" do
       setup do
         @user = create(:adopter)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
       end
 
       should "return false" do

--- a/test/policies/organizations/task_policy_test.rb
+++ b/test/policies/organizations/task_policy_test.rb
@@ -40,6 +40,16 @@ class Organizations::TaskPolicyTest < ActiveSupport::TestCase
         end
       end
 
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
       context "when user is deactivated staff" do
         setup do
           @user = create(:staff, :deactivated)
@@ -112,6 +122,16 @@ class Organizations::TaskPolicyTest < ActiveSupport::TestCase
       context "when user is adopter" do
         setup do
           @user = create(:adopter)
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
+      context "when user is fosterer" do
+        setup do
+          @user = create(:fosterer)
         end
 
         should "return false" do


### PR DESCRIPTION
# 🔗 Issue
#599

# ✍️ Description
This implements the `:fosterer` role for authz purposes. It does so by implementing `FOSTERER_PERMISSIONS`. It also adds the fosterer factory and a fosterer context to many of the policy unit tests.

Adding the fosterer factory led me to refactor the user factory slightly in regards to how roles were assigned in our factories. It would be worth making sure that those changes make sense.

## Role assignment refactor
Roles were previously being added through the account factories. This refactoring moves the role assignment to the user factory.

The roles are associated now with `User` records, not `Account` records. Coupling the accounts with the roles was making testing for role related behavior clunky, especially since adopter and fosterers share the same account type, `AdopterFosterAccount`. 

For consistency, I made these changes to staff too.

## Bug note:
I noticed before these changes that running just the `MatchPolicyTest` file caused the test runner to hang:
```
bin/rails test -v test/policies/organizations/match_policy_test.rb
```
It does not happen when running the full test suite. It seems to be related to this issue and is fixable by one of the suggestions in that thread: https://github.com/rails/rails/issues/48468

I made note of this in slack. If we can replicate this error and it starts affecting other test files, we can implement the fix from that issue but otherwise I think we can ignore it for now.