### PR TITLE
Add instructions for Postgres

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 [code of conduct]: https://github.com/rubyforgood/code-of-conduct
 [open issue]: https://github.com/rubyforgood/pet-rescue/issues?q=is%3Aissue+is%3Aopen+no%3Aassignee
-[set up instructions]: https://github.com/rubyforgood/pet-rescue#local-setup
+[set up instructions]: https://github.com/rubyforgood/pet-rescue#install--setup
 
 We ♥ contributors! By participating in this project, you agree to abide by the
 Ruby for Good [code of conduct].

--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ Let's get your machine setup to startup the application!
 ⚠️  We assume you already have ruby installed with your preferred version manager. This codebase supports [rbenv](
 https://github.com/rbenv/rbenv) and [asdf](https://github.com/asdf-vm/asdf-ruby).
 
+### PostgreSQL
+
+Installing PostgreSQL is required to run the application.
+
+#### Installing on MacOS
+
+Instructions: https://wiki.postgresql.org/wiki/Homebrew
+
+```sh
+brew install postgresql
+```
+
+#### Running as a service
+
+```sh
+brew services start postgresql
+```
+
 ## 🤝 Contributing Guidelines 
 
 Please feel free to contribute! Priority will be given to pull requests that address outstanding issues and have appropriate test coverage. Focus on issues tagged with the next milestone for higher priority.
@@ -55,7 +73,8 @@ Create a new `config/application.yml` file from the `config/application.example.
 cp config/application.example.yml config/application.yml
 ```
 
-Update your `config/application.yml` by replacing the places that say REPLACE_ME.
+Update your `config/application.yml` by replacing the places that say REPLACE_ME. If you installed and configured PostgreSQL as discussed above
+you can use your username and leave the password blank for development.
 
 Run the setup script to prepare DB and assets
 ```sh


### PR DESCRIPTION
Postgres is needed to run locally, but the instructions didn't mention this. This minor change provides instructions that help get started running locally on MacOS.