### PR TITLE
Change matches table to handle adoptions and fosters

### DIFF
--- a/app/controllers/organizations/matches_controller.rb
+++ b/app/controllers/organizations/matches_controller.rb
@@ -31,7 +31,7 @@ class Organizations::MatchesController < Organizations::BaseController
   private
 
   def match_params
-    params.require(:match).permit(:pet_id, :adopter_foster_account_id)
+    params.require(:match).permit(:pet_id, :adopter_foster_account_id, :match_type, :start_date, :end_date)
   end
 
   def set_pet

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -3,6 +3,9 @@
 # Table name: matches
 #
 #  id                        :bigint           not null, primary key
+#  end_date                  :datetime
+#  match_type                :integer          not null
+#  start_date                :datetime
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  adopter_foster_account_id :bigint           not null

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -33,6 +33,8 @@ class Match < ApplicationRecord
 
   after_create_commit :send_reminder
 
+  enum :match_type, [:adoption, :foster]
+
   def send_reminder
     MatchMailer.reminder(self).deliver_later
   end

--- a/app/views/organizations/pets/tabs/partials/_application_status.html.erb
+++ b/app/views/organizations/pets/tabs/partials/_application_status.html.erb
@@ -30,7 +30,9 @@
       <!--create adoption button-->
       <%= button_to "New Adoption", matches_path, method: :post,
         params: {match:
-          {pet_id: app.pet_id, adopter_foster_account_id: app.adopter_foster_account_id}
+          {pet_id: app.pet_id, 
+           adopter_foster_account_id: app.adopter_foster_account_id,
+           match_type: :adoption}
         },
         class: "btn btn-outline-primary",
         data: { turbo_method: :post, 

--- a/db/migrate/20240418120309_add_match_type_to_matches.rb
+++ b/db/migrate/20240418120309_add_match_type_to_matches.rb
@@ -1,0 +1,7 @@
+class AddMatchTypeToMatches < ActiveRecord::Migration[7.1]
+  def change
+    add_column :matches, :match_type, :integer, null: false
+    add_column :matches, :start_date, :datetime
+    add_column :matches, :end_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_08_194612) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_18_120309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -135,6 +135,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_08_194612) do
     t.datetime "updated_at", null: false
     t.bigint "adopter_foster_account_id", null: false
     t.bigint "organization_id", null: false
+    t.integer "match_type", null: false
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.index ["adopter_foster_account_id"], name: "index_matches_on_adopter_foster_account_id"
     t.index ["organization_id"], name: "index_matches_on_organization_id"
     t.index ["pet_id"], name: "index_matches_on_pet_id", unique: true

--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -258,7 +258,8 @@ ActsAsTenant.with_tenant(@organization) do
 
   @match = Match.create!(
     pet_id: Pet.first.id,
-    adopter_foster_account_id: @adopter_foster_account_one.id
+    adopter_foster_account_id: @adopter_foster_account_one.id,
+    match_type: :adoption
   )
 
   10.times do

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -258,7 +258,8 @@ ActsAsTenant.with_tenant(@organization) do
 
   @match = Match.create!(
     pet_id: Pet.first.id,
-    adopter_foster_account_id: @adopter_foster_account_one.id
+    adopter_foster_account_id: @adopter_foster_account_one.id,
+    match_type: :adoption
   )
 
   10.times do

--- a/test/controllers/organizations/matches_controller_test.rb
+++ b/test/controllers/organizations/matches_controller_test.rb
@@ -19,7 +19,8 @@ class Organizations::MatchesControllerTest < ActionDispatch::IntegrationTest
         @params = {
           match: {
             pet_id: pet.id,
-            adopter_foster_account_id: adopter_foster_account.id
+            adopter_foster_account_id: adopter_foster_account.id,
+            match_type: :adoption
           }
         }
       end
@@ -37,7 +38,7 @@ class Organizations::MatchesControllerTest < ActionDispatch::IntegrationTest
 
     context "#destroy" do
       setup do
-        @match = create(:match)
+        @match = create(:match, match_type: :adoption)
       end
 
       should "be authorized" do

--- a/test/factories/pets.rb
+++ b/test/factories/pets.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     end
 
     trait :adopted do
-      match { association :match, pet: instance }
+      match { association :match, pet: instance, match_type: :adoption }
       adopter_applications { build_list(:adopter_application, 1, :successful_applicant, pet: instance) }
     end
 

--- a/test/mailers/match_mailer_test.rb
+++ b/test/mailers/match_mailer_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class MatchMailerTest < ActionMailer::TestCase
   test "reminder" do
-    match = create(:match)
+    match = create(:match, match_type: :adoption)
     email = MatchMailer.reminder(match)
 
     assert_emails 1 do

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -8,6 +8,10 @@ class MatchTest < ActiveSupport::TestCase
     should belong_to(:adopter_foster_account)
   end
 
+  context "validations" do
+    should define_enum_for(:match_type)
+  end
+
   setup do
     @match = build_stubbed(:match)
   end

--- a/test/policies/organizations/match_policy_test.rb
+++ b/test/policies/organizations/match_policy_test.rb
@@ -101,7 +101,7 @@ class Organizations::MatchPolicyTest < ActiveSupport::TestCase
 
   context "#destroy?" do
     setup do
-      @match = create(:match)
+      @match = create(:match, match_type: :adoption)
       @policy = -> {
         Organizations::MatchPolicy.new(@match, user: @user)
       }
@@ -146,7 +146,7 @@ class Organizations::MatchPolicyTest < ActiveSupport::TestCase
       context "when match belongs to a different organization" do
         setup do
           ActsAsTenant.with_tenant(create(:organization)) do
-            @match = create(:match)
+            @match = create(:match, match_type: :adoption)
           end
         end
 
@@ -180,7 +180,7 @@ class Organizations::MatchPolicyTest < ActiveSupport::TestCase
       context "when match belongs to a different organization" do
         setup do
           ActsAsTenant.with_tenant(create(:organization)) do
-            @match = create(:match)
+            @match = create(:match, match_type: :adoption)
           end
         end
 


### PR DESCRIPTION
Resolves #643 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This adds the following columns to the Matches table:

`match_type` with null false and enum for `adoption` and `foster`
`start_date :datetime`
`end_date :datetime`

The model was updated for the enum and the controller updated for the new params. The finalize adoption button adds the match_type param. Seeds updated for adoptions.

Test were updated. The only new test added is the validation of the enum. If there is any other new test coverage you can think of please let me know.


