### PR TITLE
474 Add FAQ table and model

### DIFF
--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: faqs
+#
+#  id              :bigint           not null, primary key
+#  answer          :text             not null
+#  order           :integer
+#  question        :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_faqs_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+class Faq < ApplicationRecord
+  acts_as_tenant(:organization)
+
+  validates :question, presence: true
+  validates :answer, presence: true
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,6 +20,7 @@ class Organization < ApplicationRecord
   has_many :users, through: :staff_accounts
   has_many :pets
   has_many :default_pet_tasks
+  has_many :faqs
 
   has_one :profile, dependent: :destroy, class_name: "OrganizationProfile", required: true
   has_one :location, through: :profile

--- a/db/migrate/20240419164004_create_faqs.rb
+++ b/db/migrate/20240419164004_create_faqs.rb
@@ -1,0 +1,12 @@
+class CreateFaqs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :faqs do |t|
+      t.string :question, null: false
+      t.text :answer, null: false
+      t.integer :order
+      t.references :organization, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_18_120309) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_19_164004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -118,6 +118,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_18_120309) do
     t.integer "due_in_days"
     t.boolean "recurring", default: false
     t.index ["organization_id"], name: "index_default_pet_tasks_on_organization_id"
+  end
+
+  create_table "faqs", force: :cascade do |t|
+    t.string "question", null: false
+    t.text "answer", null: false
+    t.integer "order"
+    t.bigint "organization_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_faqs_on_organization_id"
   end
 
   create_table "locations", force: :cascade do |t|
@@ -272,6 +282,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_18_120309) do
   add_foreign_key "adopter_foster_profiles", "adopter_foster_accounts"
   add_foreign_key "adopter_foster_profiles", "locations"
   add_foreign_key "default_pet_tasks", "organizations"
+  add_foreign_key "faqs", "organizations"
   add_foreign_key "matches", "adopter_foster_accounts"
   add_foreign_key "matches", "pets"
   add_foreign_key "organization_profiles", "locations"

--- a/test/factories/faqs.rb
+++ b/test/factories/faqs.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :faq do
-    question { "MyString" }
-    answer { "MyText" }
-    order { 1 }
-    organization { nil }
+    question { Faker::Lorem.question }
+    answer { Faker::Lorem.sentence }
+    order { nil }
+    organization { ActsAsTenant.current_tenant }
   end
 end

--- a/test/factories/faqs.rb
+++ b/test/factories/faqs.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :faq do
+    question { "MyString" }
+    answer { "MyText" }
+    order { 1 }
+    organization { nil }
+  end
+end

--- a/test/models/faq_test.rb
+++ b/test/models/faq_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FaqTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/faq_test.rb
+++ b/test/models/faq_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class FaqTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  context "validations" do
+    should validate_presence_of(:question)
+    should validate_presence_of(:answer)
+  end
 end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -7,6 +7,7 @@ class OrganizationTest < ActiveSupport::TestCase
     should have_many(:staff_accounts)
     should have_many(:users).through(:staff_accounts)
     should have_many(:pets)
+    should have_many(:faqs)
 
     should have_one(:profile).dependent(:destroy).required
     should have_one(:page_text).dependent(:destroy)


### PR DESCRIPTION
Resolves #474 
<!-- Add link to the issue -->


# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Add faq table and model to allow an org to CRUD faq questions and answers. FAQ's are able to be added via the console.

FAQ table:
`question :string` null false
`answer :text` null false
`order :integer`
index faqs on organization_id / foreign key

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
![Screenshot from 2024-04-19 13-13-02](https://github.com/rubyforgood/pet-rescue/assets/16829344/c06eb08a-6fac-47f9-93ac-bb0f2a273e86)

