### PR TITLE
664 Redirect to dashboard

### DIFF
--- a/app/controllers/concerns/organization_scopable.rb
+++ b/app/controllers/concerns/organization_scopable.rb
@@ -16,10 +16,15 @@ module OrganizationScopable
 
   def after_sign_in_path_for(resource_or_scope)
     if allowed_to?(
-      :index?, Pet, namespace: Organizations,
+      :index?, with: Organizations::DashboardPolicy,
       context: {organization: Current.organization}
     )
       dashboard_index_path
+    elsif allowed_to?(
+      :index?, with: Organizations::AdopterFosterDashboardPolicy,
+      context: {organization: Current.organization}
+    )
+      adopter_foster_dashboard_index_path
     else
       adoptable_pets_path
     end


### PR DESCRIPTION
# 🔗 Issue
#664 

# ✍️ Description
This updates `after_sign_in_path_for` so that adopters and fosterers are redirected to their dashboard now upon login. It also updates the current if statement so that the staff dashboard redirect is using the `DashboardPolicy` instead of `PetPolicy` (which was old logic).