### PR TITLE
feat: replace dummy contact info with org info

### DIFF
--- a/app/models/adopter_foster_profile.rb
+++ b/app/models/adopter_foster_profile.rb
@@ -53,6 +53,7 @@
 #  fk_rails_...  (location_id => locations.id)
 #
 class AdopterFosterProfile < ApplicationRecord
+  include Phoneable
   acts_as_tenant(:organization)
   belongs_to :location, dependent: :destroy
   belongs_to :adopter_foster_account
@@ -133,28 +134,9 @@ class AdopterFosterProfile < ApplicationRecord
     visit_laventana == true
   end
 
-  def formatted_phone
-    parsed_phone = Phonelib.parse(phone_number)
-    return phone_number if parsed_phone.invalid?
-
-    formatted =
-      if parsed_phone.country_code == "1" # NANP
-        parsed_phone.full_national # (415) 555-2671;123
-      else
-        parsed_phone.full_international # +44 20 7183 8750
-      end
-    formatted.gsub!(";", " x") # (415) 555-2671 x123
-    formatted
-  end
-
   # used in views to show only the custom error msg without leading attribute
   def custom_messages(attribute)
     errors.where(attribute)
   end
 
-  private
-
-  def normalize_phone
-    self.phone_number = Phonelib.parse(phone_number).full_e164.presence
-  end
 end

--- a/app/models/adopter_foster_profile.rb
+++ b/app/models/adopter_foster_profile.rb
@@ -138,5 +138,4 @@ class AdopterFosterProfile < ApplicationRecord
   def custom_messages(attribute)
     errors.where(attribute)
   end
-
 end

--- a/app/models/concerns/phoneable.rb
+++ b/app/models/concerns/phoneable.rb
@@ -1,0 +1,29 @@
+# Module to handle phone number normalization before save and formatting
+# Note that we are not handling validation here as different models may have different validation requirements (e.g. presence)
+module Phoneable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :normalize_phone
+
+    def formatted_phone_number
+      parsed_phone = Phonelib.parse(phone_number)
+      return phone_number if parsed_phone.invalid?
+
+      formatted =
+        if parsed_phone.country_code == "1" # NANP
+          parsed_phone.full_national # (415) 555-2671;123
+        else
+          parsed_phone.full_international # +44 20 7183 8750
+        end
+      formatted.gsub!(";", " x") # (415) 555-2671 x123
+      formatted
+    end
+
+    private
+
+    def normalize_phone
+      self.phone_number = Phonelib.parse(phone_number).full_e164.presence
+    end
+  end
+end

--- a/app/models/organization_profile.rb
+++ b/app/models/organization_profile.rb
@@ -25,6 +25,7 @@
 #
 class OrganizationProfile < ApplicationRecord
   include Avatarable
+  include Phoneable
 
   belongs_to :location
   acts_as_tenant(:organization, inverse_of: :profile)

--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -76,9 +76,9 @@
         <!-- contact info -->
         <div class="mb-4">
           <h3 class="fw-bold mb-3">Get in touch</h3>
-          <p>339 McDermott Points Hettingerhaven, NV 15283</p>
-          <p class="mb-1">Email: <a href="#">support@geeksui.com</a></p>
-          <p>Phone: <span class="text-dark fw-semibold">(000) 123 456 789</span></p>
+          <p><%= Current.tenant.location.city_town %>, <%= Current.tenant.location.province_state %> <%= Current.tenant.location.country %></p>
+          <p class="mb-1">Email: <a href="mailto:<%= Current.tenant.profile.email %>"><%= Current.tenant.profile.email %></a></p>
+          <p>Phone: <span class="text-dark fw-semibold"><%= Current.tenant.profile.phone_number %></span></p>
         </div>
       </div>
     </div>

--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -78,7 +78,9 @@
           <h3 class="fw-bold mb-3">Get in touch</h3>
           <p><%= Current.tenant.location.city_town %>, <%= Current.tenant.location.province_state %> <%= Current.tenant.location.country %></p>
           <p class="mb-1">Email: <a href="mailto:<%= Current.tenant.profile.email %>"><%= Current.tenant.profile.email %></a></p>
-          <p>Phone: <span class="text-dark fw-semibold"><%= Current.tenant.profile.phone_number %></span></p>
+          <% if Current.tenant.profile.phone_number.present? %>
+            <p>Phone: <span class="text-dark fw-semibold"><%= Current.tenant.profile.formatted_phone_number %></span></p>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/organizations/adopter_fosterer/profiles/show.html.erb
+++ b/app/views/organizations/adopter_fosterer/profiles/show.html.erb
@@ -27,7 +27,7 @@
             <div class="row mb-3 bigger">
               <p class="col-lg-4"><strong><%= t('.phone_number') %></strong></p>
               <p class="col-lg-6 text-muted">
-                <%= @adopter_foster_profile.formatted_phone %>
+                <%= @adopter_foster_profile.formatted_phone_number %>
               </p>
             </div>
             <div class="row mb-3 bigger">

--- a/app/views/organizations/staff/profile_reviews/show.html.erb
+++ b/app/views/organizations/staff/profile_reviews/show.html.erb
@@ -25,7 +25,7 @@
             <div class="row mb-3 bigger">
               <p class="col-lg-4"><strong>Phone Number</strong></p>
               <p class="col-lg-6 text-muted">
-                <%= @adopter_foster_profile.formatted_phone %>
+                <%= @adopter_foster_profile.formatted_phone_number %>
               </p>
             </div>
             <div class="row mb-3 bigger">

--- a/test/models/concerns/phoneable_test.rb
+++ b/test/models/concerns/phoneable_test.rb
@@ -50,4 +50,3 @@ class PhoneableTest < ActiveSupport::TestCase
     end
   end
 end
-

--- a/test/models/concerns/phoneable_test.rb
+++ b/test/models/concerns/phoneable_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class PhoneableTest < ActiveSupport::TestCase
+  class DummyPhoneable
+    extend ActiveModel::Callbacks
+    define_model_callbacks :save
+
+    include Phoneable
+    attr_accessor :phone_number
+
+    def save
+      run_callbacks :save do
+        # dummy save action, don't actually do anything
+      end
+    end
+  end
+
+  setup do
+    @phoneable = DummyPhoneable.new
+  end
+
+  context "#formatted_phone_number" do
+    should "return properly formatted phone number" do
+      @phoneable.phone_number = "+12508168212"
+      assert_equal "(250) 816-8212", @phoneable.formatted_phone_number
+    end
+
+    should "return properly formatted international phone number" do
+      @phoneable.phone_number = "+442071838750"
+      assert_equal "+44 20 7183 8750", @phoneable.formatted_phone_number
+    end
+
+    should "return original phone number if invalid" do
+      @phoneable.phone_number = "123"
+      assert_equal "123", @phoneable.formatted_phone_number
+    end
+  end
+
+  context "before_save callback" do
+    should "normalize phone number" do
+      @phoneable.phone_number = "(250) 816-8212"
+      @phoneable.save
+      assert_equal "+12508168212", @phoneable.phone_number
+    end
+
+    should "not normalize nil phone number" do
+      @phoneable.phone_number = nil
+      @phoneable.save
+      assert_nil @phoneable.phone_number
+    end
+  end
+end
+

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -8,9 +8,17 @@ class HomePageTest < ApplicationSystemTestCase
   end
 
   test "renders custom hero and about text from PageText or default text" do
-    PageText.create(hero: "Super Pets for a good paws", about: "All about us")
+    create(:page_text, hero: "Super Pets for a good paws", about: "All about us")
+
     visit home_index_path
     assert_text "Super Pets for a good paws"
     assert_text "All about us"
+
+    # Should render the organization location information
+    assert_text @organization.location.city_town
+    assert_text @organization.location.province_state
+    assert_text @organization.location.country
+    assert_text @organization.profile.email
+    assert_text @organization.profile.phone_number
   end
 end

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -8,17 +8,10 @@ class HomePageTest < ApplicationSystemTestCase
   end
 
   test "renders custom hero and about text from PageText or default text" do
-    create(:page_text, hero: "Super Pets for a good paws", about: "All about us")
+    PageText.create(hero: "Super Pets for a good paws", about: "All about us")
 
     visit home_index_path
     assert_text "Super Pets for a good paws"
     assert_text "All about us"
-
-    # Should render the organization location information
-    assert_text @organization.location.city_town
-    assert_text @organization.location.province_state
-    assert_text @organization.location.country
-    assert_text @organization.profile.email
-    assert_text @organization.profile.phone_number
   end
 end


### PR DESCRIPTION
Adds the organization contact information to the footer partial

# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/171

# ✍️ Description
- Replaces the dummy contact info in the footer with the org's contact info

# 📷 Screenshots/Demos
![image](https://github.com/rubyforgood/pet-rescue/assets/90267290/0db23e87-2fbc-46c7-a31b-44e1ee047e1b)

