### PR TITLE
Fix Baja Seed File

### DIFF
--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -288,6 +288,4 @@ ActsAsTenant.with_tenant(@organization) do
       answer: Faker::Lorem.sentence(word_count: 1, random_words_to_add: 50)
     )
   end
-
-  PageText.create!(hero: nil, about: nil)
 end


### PR DESCRIPTION
Resolves #682 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Currently the PageText data will not displaying for Baja org but will display for Alta.

The seed file for Baja has a second creation of PageText which is believed to be causing an issue with the `home/index` view. This PR removes the second PageText.create

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
