### PR TITLE
fix(700): fix path helper method name

### DIFF
--- a/app/controllers/organizations/staff/page_texts_controller.rb
+++ b/app/controllers/organizations/staff/page_texts_controller.rb
@@ -8,7 +8,7 @@ class Organizations::Staff::PageTextsController < Organizations::BaseController
     if @page_text.update(page_text_params)
       redirect_to edit_staff_page_text_path, notice: "Page text updated successfully!"
     else
-      redirect_to edit_page_text_path, alert: @page_text.errors.full_messages.to_sentence
+      redirect_to edit_staff_page_text_path, alert: @page_text.errors.full_messages.to_sentence
     end
   end
 


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/700

# ✍️ Description
Changed the edit_page_text_path to edit_staff_page_text_path in Organizations::Staff::PageTextsController in the update action as suggested in original issue

<img width="721" alt="Screenshot 2024-05-13 at 00 41 02" src="https://github.com/rubyforgood/pet-rescue/assets/35756574/2df99be1-4809-4415-a08c-9e167a2fd4dd">

