### PR TITLE
Fixed bug where staff were not allowed to visit staff_manage_fosters_path

### DIFF
--- a/app/controllers/organizations/staff/manage_fosters_controller.rb
+++ b/app/controllers/organizations/staff/manage_fosters_controller.rb
@@ -2,5 +2,7 @@ class Organizations::Staff::ManageFostersController < Organizations::BaseControl
   layout "dashboard"
 
   def index
+    authorize! User, context: {organization: Current.organization},
+      with: Organizations::ManageFostersPolicy
   end
 end

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -30,6 +30,7 @@ STAFF_PERMISSIONS = (
     invite_fosterers
     purge_attachments
     manage_default_pet_tasks
+    manage_fosters
     manage_forms
     manage_questions
     manage_matches

--- a/app/policies/organizations/manage_fosters_policy.rb
+++ b/app/policies/organizations/manage_fosters_policy.rb
@@ -1,0 +1,8 @@
+class Organizations::ManageFostersPolicy < ApplicationPolicy
+  pre_check :verify_organization!
+  pre_check :verify_active_staff!
+
+  def index?
+    permission?(:manage_fosters)
+  end
+end

--- a/test/policies/organizations/manage_fosters_policy_test.rb
+++ b/test/policies/organizations/manage_fosters_policy_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+# See https://actionpolicy.evilmartians.io/#/testing?id=testing-policies
+class Organizations::ManageFostersPolicyTest < ActiveSupport::TestCase
+  include PetRescue::PolicyAssertions
+
+  setup do
+    @staff = create(:staff_account)
+    @policy = -> { Organizations::ManageFostersPolicy.new(@staff, user: @user) }
+  end
+
+  context "#index?" do
+    setup do
+      @action = -> { @policy.call.apply(:index?) }
+    end
+
+    context "when user is nil" do
+      setup do
+        @user = nil
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is adopter" do
+      setup do
+        @user = create(:adopter)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is fosterer" do
+      setup do
+        @user = create(:fosterer)
+      end
+
+      should "return false" do
+        assert_equal @action.call, false
+      end
+    end
+
+    context "when user is staff" do
+      setup do
+        @user = create(:staff)
+      end
+
+      should "return false" do
+        assert_equal @action.call, true
+      end
+    end
+
+    context "when user is staff admin" do
+      setup do
+        @user = create(:staff_admin)
+      end
+
+      context "when user's staff account is deactivated" do
+        setup do
+          @user.staff_account.deactivate
+        end
+
+        should "return false" do
+          assert_equal @action.call, false
+        end
+      end
+
+      should "return true" do
+        assert_equal @action.call, true
+      end
+    end
+  end
+end


### PR DESCRIPTION
TODO: Page now needs to render useful content ;-)

# 🔗 Issue
Fixes https://github.com/rubyforgood/pet-rescue/issues/716

# ✍️ Description
Added policy for Organization::ManageFostersController on #index to ensure there is a user and that user is staff. Also added policy test to be sure this works. Didn't TDD so broke my test by removing the `manage_fosters` permission from the STAFF constant to ensure that the test failed as desired without the permission.