### PR TITLE
Fix Staff deactivate toggle

### DIFF
--- a/app/views/organizations/staff/staff/_deactivate_toggle.html.erb
+++ b/app/views/organizations/staff/staff/_deactivate_toggle.html.erb
@@ -1,4 +1,4 @@
-<div id=<%= "staff_deactivate_toggle_#{staff.id}" %>>
+<div class=<%= "staff_deactivate_toggle_#{staff.id}" %>>
   <%= form_with model: staff, url: staff_staff_update_activation_path(staff), method: "post" do |form| %>
     <div class='form-group d-flex justify-content-center'>
       <div class="form-check form-switch">

--- a/app/views/organizations/staff/staff/update.turbo_stream.erb
+++ b/app/views/organizations/staff/staff/update.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.replace "staff_deactivate_toggle_#{@staff_account.id}", partial: "deactivate_toggle",
+<%= turbo_stream.replace_all ".staff_deactivate_toggle_#{@staff_account.id}", partial: "deactivate_toggle",
 locals: {staff: @staff_account} %>


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
Resolves #723 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This fixes the staff deactivate toggle by using replace_all and targeting a class instead of an id.

The page loads both cards and tables at the same time so one staff member would have two toggles with the same id on the page causing issues. By changing the id to a class and targeting all classes matching the target name this resolves the issue.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
[Screencast from 05-17-2024 07:07:23 AM.webm](https://github.com/rubyforgood/pet-rescue/assets/16829344/3ccc6588-f76c-446a-a1fa-84b25c076846)

