### PR TITLE
Temp fix for About Us images with varying size/aspect ratios

### DIFF
--- a/app/views/organizations/home/index.html.erb
+++ b/app/views/organizations/home/index.html.erb
@@ -10,7 +10,7 @@
             <p class="lead mb-4 text-black"><%= Current.organization.page_text&.hero || "Where every paw finds a home" %></p>
           </div>
           <div class="d-flex justify-content-center">
-          <%= link_to '#', class: "btn btn-dark btn-lg rounded-1 me-2" do %>
+            <%= link_to '#', class: "btn btn-dark btn-lg rounded-1 me-2" do %>
               Volunteer
             <% end %>
             <%= link_to adoptable_pets_path, class: "btn btn-primary btn-lg rounded-1 ms-2" do %>
@@ -22,7 +22,6 @@
     </div>
   </div>
 </section>
-
 
 <!--//? ADOPTION -->
 <section class="pt-5 pb-5" id="adopt">
@@ -129,22 +128,23 @@
   </div>
 </section>
 
-
 <!-- ABOUT US-->
 <section class="bg-light pt-5 pb-5" id="about_us">
   <div class="container mb-md-5 mt-md-5">
     <div class="text-center mb-5">
-        <h2 class="section-heading text-uppercase underline">
+      <h2 class="section-heading text-uppercase underline">
         About us
-        </h2>
+      </h2>
     </div>
     <div class="row pb-3">
       <div class="col-lg-4 col-md-6 mb-4 mb-lg-0">
-        <span>
+        <span class="ratio ratio-1x1 w-100 border border-0">
           <% if Current.organization.page_text.about_us_images.attached? && Current.organization.page_text.about_us_images.count > 0 %>
-            <%= image_tag(Current.organization.page_text.about_us_images.first, class: 'rounded-5 w-100 px-4 px-lg-0') %>
+            <%= image_tag(Current.organization.page_text.about_us_images.first,
+          class: 'rounded-5 w-100 px-4 px-lg-0', style: "object-fit: cover;") %>
           <% else %>
-            <%= image_tag('danielle_2.jpg', class: 'rounded-5 w-100 px-4 px-lg-0') %>
+            <%= image_tag('danielle_2.jpg', class: 'rounded-5 w-100 px-4 px-lg-0',
+          style: "object-fit: cover;") %>
           <% end %>
         </span>
       </div>
@@ -157,16 +157,21 @@
         </p>
       </div>
       <div class="col-lg-4 col-md-6 d-none d-md-block mb-4 mb-lg-0">
-        <span>
+        <span class="ratio ratio-1x1 w-100 border border-0">
           <% if Current.organization.page_text.about_us_images.attached? && Current.organization.page_text.about_us_images.count >= 2 %>
-            <%= image_tag(Current.organization.page_text.about_us_images.second, class: 'w-100 rounded-5 px-4 px-lg-0') %>
+            <%= image_tag(Current.organization.page_text.about_us_images.second,
+          class: 'w-100 rounded-5 px-4 px-lg-0', style: "object-fit: cover;") %>
           <% else %>
-            <%= image_tag('danielle_3.jpg', class: 'w-100 rounded-5 px-4 px-lg-0') %>
+
+            <%= image_tag('danielle_3.jpg', class: 'rounded-5 px-4
+                          px-lg-0', style: "object-fit: cover;") %>
           <% end %>
         </span>
       </div>
-    </div> <!--row-->
-  </div> <!--container-->
+    </div>
+    <!--row-->
+  </div>
+  <!--container-->
 </section>
 
 <% unless user_signed_in? %>
@@ -181,7 +186,7 @@
                       class: 'custom-btn-pink' %>
         </div>
       </div>
-    </div> <!--container-->
+    </div>
+    <!--container-->
   </section>
 <% end %>
-


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
#701 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This is a temporary fix to ensure a consistent layout on the org home page. Org staff can upload two images without any constraints on their dimensions.

This PR uses a ratio of 1:1. The ratio can be changed via bootstrap if there is a aspect ratio that better fits the layout and would least affect the most common upload dimensions. 

Compromise:
- Landscape photos will be cropped on the left and right
- Portrait photos will be cropped top and bottom


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

![Screenshot from 2024-05-17 18-13-25](https://github.com/rubyforgood/pet-rescue/assets/16829344/c764a9e4-6b2c-4cbc-a11d-ce74f5c62af1)
