### PR TITLE
718 allow staff customize text adoptable pet show

### DIFF
--- a/app/controllers/organizations/adoptable_pets_controller.rb
+++ b/app/controllers/organizations/adoptable_pets_controller.rb
@@ -9,6 +9,7 @@ class Organizations::AdoptablePetsController < Organizations::BaseController
   end
 
   def show
+    @adoptable_pet_info = PageText.first&.adoptable_pet_info
     @pet = Pet.find(params[:id])
     authorize! @pet, with: Organizations::AdoptablePetPolicy
 

--- a/app/controllers/organizations/staff/page_texts_controller.rb
+++ b/app/controllers/organizations/staff/page_texts_controller.rb
@@ -15,7 +15,7 @@ class Organizations::Staff::PageTextsController < Organizations::BaseController
   private
 
   def page_text_params
-    params.require(:page_text).permit(:hero, :about, :hero_image, about_us_images: [])
+    params.require(:page_text).permit(:hero, :about, :hero_image, :adoptable_pet_info, about_us_images: [])
   end
 
   def set_page_text

--- a/app/models/page_text.rb
+++ b/app/models/page_text.rb
@@ -2,12 +2,13 @@
 #
 # Table name: page_texts
 #
-#  id              :bigint           not null, primary key
-#  about           :text
-#  hero            :string
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organization_id :bigint           not null
+#  id                 :bigint           not null, primary key
+#  about              :text
+#  adoptable_pet_info :text
+#  hero               :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  organization_id    :bigint           not null
 #
 # Indexes
 #

--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -75,7 +75,7 @@
               <p class="fs-3  mb-5"><%= t('.please_read_faq_html', faq_link: link_to('FAQ', faq_index_path)) %></p>
             </div>
 
-            <% if @adoptable_pet_info %>
+            <% if @adoptable_pet_info.present? %>
               <div class="row align-items-center">
                 <div class="mb-6">
                   <h3 class="mb-3 fw-bold"><%= t('.important_info') %></h3>

--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -73,24 +73,18 @@
               <span class="text-uppercase text-primary fw-semibold ls-md"><%= t('.adoption_process') %></span>
               <!-- para -->
               <p class="fs-3  mb-5"><%= t('.please_read_faq_html', faq_link: link_to('FAQ', faq_index_path)) %></p>
-
             </div>
 
-            <div class=" row align-items-center ">
-              <div class="mb-6">
-                <h3 class="mb-3 fw-bold"><%= t('.please_know_that') %></h3>
-                <p class="mb-0 fs-4 ">
-                <ul><%= t('.please_know_that_items_html') %></ul>
-                </p>
+            <% if @adoptable_pet_info %>
+              <div class="row align-items-center">
+                <div class="mb-6">
+                  <h3 class="mb-3 fw-bold"><%= t('.important_info') %></h3>
+                  <p class="mb-0 fs-4 ">
+                    <%= @adoptable_pet_info %>
+                  </p>
+                </div>
               </div>
-              <!-- content -->
-              <div class="mb-6">
-                <h3 class="mb-3 fw-bold"><%= t('.after_you_adopt') %></h3>
-                <p class="mb-0 fs-4 ">
-                <ul><%= t('.after_you_adopt_items_html') %></ul>
-                </p>
-              </div>
-            </div>
+            <% end %>
 
           </div>
 

--- a/app/views/organizations/staff/page_texts/_form.html.erb
+++ b/app/views/organizations/staff/page_texts/_form.html.erb
@@ -34,6 +34,10 @@
               <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
             <% end %>
             <small class="form-text text-muted">You can upload up to 2 images. <br> Images must be .png or .jpeg under 2MB </small>
+            <h3 class="mt-4">Adoptable Pet Information</h3>
+            <div class="form-group">
+              <%= form.text_area :adoptable_pet_info, label: "Information for adopters", placeholder: "Anything you would like adopters to know?", class: 'form-control' %>
+            </div>
         <% end %>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,6 +301,7 @@ en:
         complete_my_profile: "Complete my profile"
         adopt: "Adopt"
         login: "Log in"
+        important_info: "Important Information"
     faq:
       index:
         header: "Frequently Asked Questions"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,21 +272,6 @@ en:
       show:
         adoption_process: "Adoption Process"
         please_read_faq_html: "Please read the %{faq_link} before applying to adopt."
-        please_know_that: "Please know that"
-        please_know_that_items_html: |
-          <li>Adopters must be located in Canada, USA or Mexico</li>
-          <li>There is an adoption fee of $175 USD</li>
-          <li>Every pet will be fully vaccinated and have the necessary
-          paperwork to enter Canada/USA</li>
-          <li>We can usually arrange transport to adopters west of Alberta or
-          Nevada only. Adopters further east will need to arrange
-          transport before an adoption can be approved.</li>
-        after_you_adopt: "After you apply to adopt"
-        after_you_adopt_items_html: |
-          <li>Your application history will be shown on 'My Applications' page</li>
-          <li>Application reviews generally take 4-6 days, depending on volume</li>
-          <li>We will contact you for further discussion if you are shortlisted </li>
-          <li>We work hard to match pets and adopters, so please try again if you are not successful first time round </li>
         create_an_account: "Create an account to apply for this pet"
         status:
           awaiting_review: Application Awaiting Review

--- a/db/migrate/20240518203140_add_adoptable_pet_info_to_page_texts.rb
+++ b/db/migrate/20240518203140_add_adoptable_pet_info_to_page_texts.rb
@@ -1,0 +1,5 @@
+class AddAdoptablePetInfoToPageTexts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :page_texts, :adoptable_pet_info, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_20_000000) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_18_203140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -214,6 +214,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_20_000000) do
     t.text "about"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "adoptable_pet_info"
     t.index ["organization_id"], name: "index_page_texts_on_organization_id"
   end
 

--- a/test/integration/adoptable_pet_show_test.rb
+++ b/test/integration/adoptable_pet_show_test.rb
@@ -126,4 +126,19 @@ class AdoptablePetShowTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  context "with adoptable pet information" do
+    should "have important information section" do
+      PageText.create(adoptable_pet_info: "some things that should be known")
+      get adoptable_pet_path(@available_pet)
+      assert_select "h3", text: "Important Information", count: 1
+    end
+  end
+
+  context "without adoptable pet information" do
+    should "not have important information section" do
+      get adoptable_pet_path(@available_pet)
+      assert_select "h3", text: "Important Information", count: 0
+    end
+  end
 end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
#718 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Adds the new column for adoptable pet info to page texts table and updates the relevant form and the adoptable pets show view to display info if present. 

The form looked a little weird with the label and header being the same text so I tried to come up with something that would convey the same meaning but not be identical. Happy to change it if you want. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

The form with a placeholder: 

<img width="652" alt="Screenshot 2024-05-18 at 5 02 42 PM" src="https://github.com/rubyforgood/pet-rescue/assets/82609260/260d4d16-1b7c-4d38-99b6-20804aaf47d2">

Adoptable pets view with information: 

<img width="1284" alt="Screenshot 2024-05-18 at 4 59 45 PM" src="https://github.com/rubyforgood/pet-rescue/assets/82609260/71c1a3f0-cff6-4652-be10-02e873cd719b">


