### PR TITLE
Add a docker-compose file to launch local service dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,28 @@ Instructions: https://wiki.postgresql.org/wiki/Homebrew
 brew install postgresql
 ```
 
-#### Running as a service
+To run postgresql as a service:
 
 ```sh
 brew services start postgresql
 ```
+
+#### Installing via docker
+
+A `docker-compose.yml` is provided that will run postgres inside a local docker container without requiring a full OS install.
+
+Before bringing the image up, you'll need to choose a database username and password by exporting the following environment variables.
+
+Using [direnv] is recommended here, to manage environment variables locally.
+
+```
+export DATABASE_USERNAME=[your username]
+export DATABASE_PASSWORD=[a password]
+```
+
+Once your environment has been set, you may launch the postgres database, and any other dependencies, by running `docker compose up -d`
+
+[direnv]: https://direnv.net/
 
 ## Install & Setup
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   host: localhost
   username: <%= ENV['DATABASE_USERNAME'] %>
   password: <%= ENV['DATABASE_PASSWORD'] %>
+  port: <%= ENV.fetch("DATABASE_PORT", `docker compose port postgres 5432 2> /dev/null`.split(":").last || 5432) %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+---
+services:
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: ${DATABASE_USERNAME}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+      POSTGRES_DB: pet_rescue_development
+
+    ports:
+      - 5432
+
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-U", "bwoa", "-d", "pet_rescue_development"]
+      interval: 10s
+    volumes:
+      - db:/var/lib/postgresql/data
+
+volumes:
+  db:


### PR DESCRIPTION
This provides an _alternative_ to having to install a local postgres
service, and presents a mechanism for running ports isolated from any other
docker service clusters that may be running on the same machine.

# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
