### PR TITLE
Show Pet Overview for :foster type matches

### DIFF
--- a/app/views/organizations/staff/pets/tabs/_overview.html.erb
+++ b/app/views/organizations/staff/pets/tabs/_overview.html.erb
@@ -8,8 +8,8 @@
           </div>
           <div class="d-flex gap-2">
             <%= link_to t('general.edit'), edit_staff_pet_path(@pet), class: 'btn btn-outline-dark' %>
-            <%= button_to t('general.delete'), staff_pet_path(@pet), method: :delete, 
-                                               class: 'btn btn-outline-danger', 
+            <%= button_to t('general.delete'), staff_pet_path(@pet), method: :delete,
+                                               class: 'btn btn-outline-danger',
                                                data: { turbo_confirm: t('general.are_you_sure_delete_pet') } %>
           </div>
         </div>
@@ -21,7 +21,7 @@
               <th>Sex</th>
               <th>Breed</th>
               <th>Weight</th>
-              <% if @pet.matches.empty? %>
+              <% if @pet.matches.empty? || @pet.matches.last.match_type == "foster" %>
                 <th>Placement Type</th>
                 <th>Application Status</th>
                 <th>Publish Status</th>
@@ -40,7 +40,7 @@
                 <%= "#{@pet.weight_from} - #{@pet.weight_to} #{@pet.weight_unit}" %>
               </p>
             </td>
-            <% if @pet.matches.empty? %>
+            <% if @pet.matches.empty? || @pet.matches.last.match_type == "foster" %>
               <td>
                 <p class="text-dark mb-0 fw-semibold"><%= @pet.placement_type %></p>
               </td>

--- a/test/system/pet_overview_test.rb
+++ b/test/system/pet_overview_test.rb
@@ -1,0 +1,46 @@
+require "application_system_test_case"
+
+class PetOverviewTest < ApplicationSystemTestCase
+  setup do
+    user = create(:staff)
+    @pet = create(:pet)
+    @all_overview_columns = %w[Sex Breed Weight Placement_Type Application_Status Publish_Status].map { |word| word.tr("_", " ") }
+    sign_in user
+  end
+
+  context "when viewing a pet that has no matches" do
+    should "show all overview fields" do
+      visit staff_pet_path(@pet)
+      assert has_current_path?(staff_pet_path(@pet))
+
+      @all_overview_columns.each do |column|
+        assert_text(column)
+      end
+    end
+  end
+
+  context "when viewing a pet that has a foster match" do
+    should "show all overview fields" do
+      create(:foster, pet_id: @pet.id)
+
+      visit staff_pet_path(@pet)
+      assert has_current_path?(staff_pet_path(@pet))
+
+      @all_overview_columns.each do |column|
+        assert_text(column)
+      end
+    end
+  end
+
+  context "when viewing a pet that has an adopter match" do
+    should "hide some overview fields" do
+      create(:match, pet_id: @pet.id)
+
+      visit staff_pet_path(@pet)
+      assert has_current_path?(staff_pet_path(@pet))
+      (@all_overview_columns - (%w[Placement_Type Application_Status Publish_Status].map { |word| word.tr("_", " ") })).each do |column|
+        assert_text(column)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
Fixes: #754

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

We wanted to make a change to the [pet overview tab](http://127.0.0.1:3000/alta/staff/pets/32) when viewing a specific pet. Previous to the change, half of the columns in the overview table were being hidden if the pet had any matches at all. This change makes it so that if there are no matches OR the match type is `:foster`, the full overview table is still viewable by the staff. The only time part of the overview should be hidden is if a match is made that is the regular `:match` type, AKA an adopter. I added a check in the `_overview.html.erb` partial for the `:foster` type match, and added a new test file, `pet_overview_test.rb` to make sure this functionality was working. I also QA tested manually via the console, and it seems to be working.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->


A match has been made for Snickers with type :foster...



Before the conditional is updated:
<img width="779" alt="Screenshot 2024-05-31 at 9 26 33 AM" src="https://github.com/rubyforgood/pet-rescue/assets/89274915/957bce87-fa85-474e-a5c4-4e9bd745b113">


After the conditional  is updated:
<img width="793" alt="Screenshot 2024-05-31 at 9 25 51 AM" src="https://github.com/rubyforgood/pet-rescue/assets/89274915/d44d4ccd-7f7e-49bd-b085-92ab44fbb274">



