### PR TITLE
Add adoption pending badge

### DIFF
--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -12,9 +12,7 @@
           </div>
           <div class="lh-1">
             <h2 class="mb-0"><%= @pet.name %></h2>
-            <% if @pet.has_adoption_pending? %>
-              <p class="mb-0 d-block"><%= t('general.adoption_pending') %></p>
-            <% end %>
+            <%= tag.span("Adoption Pending", class: "badge bg-info") if @pet.has_adoption_pending? %>
           </div>
         </div>
         <div>

--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -12,7 +12,7 @@
           </div>
           <div class="lh-1">
             <h2 class="mb-0"><%= @pet.name %></h2>
-            <%= tag.span("Adoption Pending", class: "badge bg-info") if @pet.has_adoption_pending? %>
+            <%= content_tag(:span, t('adoption_pending'), class: "badge bg-info") if @pet.has_adoption_pending? %>
           </div>
         </div>
         <div>


### PR DESCRIPTION
# 🔗 Issue
#774 

# ✍️ Description
Remove plain adoption pending text from below pet name on the pet show page. Replace it with a badge

# 📷 Screenshots/Demos
<img width="171" alt="Screenshot 2024-05-31 at 4 08 04 PM" src="https://github.com/rubyforgood/pet-rescue/assets/114014697/ef0d6329-1a72-4274-b156-1a68610347c5">
