### PR TITLE
Ability to remove a withdrawn application from list

### DIFF
--- a/app/controllers/organizations/adopter_fosterer/adopter_applications_controller.rb
+++ b/app/controllers/organizations/adopter_fosterer/adopter_applications_controller.rb
@@ -6,7 +6,7 @@ class Organizations::AdopterFosterer::AdopterApplicationsController < Organizati
   def index
     authorize! with: AdopterApplicationPolicy
 
-    @applications = authorized_scope(AdopterApplication.all, with: AdopterApplicationPolicy)
+    @applications = authorized_scope(AdopterApplication.where(profile_show: true), with: AdopterApplicationPolicy)
   end
 
   def create

--- a/app/views/organizations/adopter_fosterer/adopter_applications/_application_cards.html.erb
+++ b/app/views/organizations/adopter_fosterer/adopter_applications/_application_cards.html.erb
@@ -21,14 +21,16 @@
       </div>
     </li>
     <li class="list-group-item d-flex justify-content-center">
-      <% unless application.status == 'withdrawn' || application.status == 'adoption_made'%>
+      <% if application.status == 'withdrawn' %>
+        Display something here please
+      <% elsif application.status != 'adoption_made' %>
         <%= button_to t("dashboard.applications.withdraw_application"),
               adopter_fosterer_adopter_application_path(application, adopter_application:
               { status: 'withdrawn'}), method: :patch, class: 'btn
             btn-outline-danger', data: { turbo_confirm:
             t("dashboard.applications.confirm_withdraw") + " for " +
             pet.name.capitalize + "?"} %>
-      <% end  %>
+      <% end %>
     </li>
   </ul>
 </div>

--- a/app/views/organizations/adopter_fosterer/adopter_applications/_application_cards.html.erb
+++ b/app/views/organizations/adopter_fosterer/adopter_applications/_application_cards.html.erb
@@ -22,14 +22,15 @@
     </li>
     <li class="list-group-item d-flex justify-content-center">
       <% if application.status == 'withdrawn' %>
-        Display something here please
+        <%= button_to t("general.delete"),
+              adopter_fosterer_adopter_application_path(application, adopter_application:
+              { profile_show: false }), method: :patch, class: 'btn btn-outline-danger',
+              data: { turbo_confirm: t("dashboard.applications.confirm_delete") } %>
       <% elsif application.status != 'adoption_made' %>
         <%= button_to t("dashboard.applications.withdraw_application"),
               adopter_fosterer_adopter_application_path(application, adopter_application:
-              { status: 'withdrawn'}), method: :patch, class: 'btn
-            btn-outline-danger', data: { turbo_confirm:
-            t("dashboard.applications.confirm_withdraw") + " for " +
-            pet.name.capitalize + "?"} %>
+              { status: 'withdrawn'}), method: :patch, class: 'btn btn-outline-danger',
+              data: { turbo_confirm: t("dashboard.applications.confirm_withdraw", pet_name: pet.name.capitalize) } %>
       <% end %>
     </li>
   </ul>

--- a/app/views/organizations/adopter_fosterer/adopter_applications/_applications_table.html.erb
+++ b/app/views/organizations/adopter_fosterer/adopter_applications/_applications_table.html.erb
@@ -37,17 +37,14 @@
           <td>
             <% if app.status == 'withdrawn' %>
               <%= button_to t("general.delete"),
-              adopter_fosterer_adopter_application_path(app, adopter_application:
-              { profile_show: false }), method: :patch, class: 'btn btn-outline-danger',
-              data: { turbo_confirm: t("dashboard.applications.confirm_delete") } %>
-            <% end %>
-            <% unless app.status == 'withdrawn' || app.status == 'adoption_made'%>
+                    adopter_fosterer_adopter_application_path(app, adopter_application:
+                    { profile_show: false }), method: :patch, class: 'btn btn-outline-danger',
+                    data: { turbo_confirm: t("dashboard.applications.confirm_delete") } %>
+            <% elsif app.status != 'adoption_made'%>
               <%= button_to t("dashboard.applications.withdraw_application"),
-              adopter_fosterer_adopter_application_path(app, adopter_application:
-              { status: 'withdrawn'}), method: :patch, class: 'btn
-            btn-outline-danger', data: { turbo_confirm:
-            t("dashboard.applications.confirm_withdraw") + " for " +
-            pet.name.capitalize + "?"} %>
+                    adopter_fosterer_adopter_application_path(app, adopter_application:
+                    { status: 'withdrawn'}), method: :patch, class: 'btn  btn-outline-danger',
+                    data: { turbo_confirm: t("dashboard.applications.confirm_withdraw", pet_name: pet.name.capitalize) } %>
             <% end  %>
           </td>
         </tr>

--- a/app/views/organizations/adopter_fosterer/adopter_applications/_applications_table.html.erb
+++ b/app/views/organizations/adopter_fosterer/adopter_applications/_applications_table.html.erb
@@ -35,6 +35,12 @@
             <%= app.human_enum_name(:status) %>
           </td>
           <td>
+            <% if app.status == 'withdrawn' %>
+              <%= button_to t("general.delete"),
+              adopter_fosterer_adopter_application_path(app, adopter_application:
+              { profile_show: false }), method: :patch, class: 'btn btn-outline-danger',
+              data: { turbo_confirm: t("dashboard.applications.confirm_delete") } %>
+            <% end %>
             <% unless app.status == 'withdrawn' || app.status == 'adoption_made'%>
               <%= button_to t("dashboard.applications.withdraw_application"),
               adopter_fosterer_adopter_application_path(app, adopter_application:

--- a/config/locales/views/dashboard.en.yml
+++ b/config/locales/views/dashboard.en.yml
@@ -9,4 +9,4 @@ en:
       status: Status
       withdraw_application: Withdraw Application
       confirm_withdraw: Withdraw your application for %{pet_name}?
-      confirm_delete: This will permanently remove this application for your dashboard.
+      confirm_delete: This will permanently remove this application from your dashboard.

--- a/config/locales/views/dashboard.en.yml
+++ b/config/locales/views/dashboard.en.yml
@@ -8,5 +8,5 @@ en:
       created: Created
       status: Status
       withdraw_application: Withdraw Application
-      confirm_withdraw: Withdraw your application
+      confirm_withdraw: Withdraw your application for %{pet_name}?
       confirm_delete: This will permanently remove this application for your dashboard.

--- a/config/locales/views/dashboard.en.yml
+++ b/config/locales/views/dashboard.en.yml
@@ -9,3 +9,4 @@ en:
       status: Status
       withdraw_application: Withdraw Application
       confirm_withdraw: Withdraw your application
+      confirm_delete: This will permanently remove this application for your dashboard.

--- a/test/system/adoption_fosterer_test.rb
+++ b/test/system/adoption_fosterer_test.rb
@@ -1,0 +1,23 @@
+require "application_system_test_case"
+
+class AdoptionFostererTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:fosterer, :with_profile)
+    @organization = @user.organization
+    @page_text = create(:page_text, :with_image, organization: @organization)
+    Current.organization = @organization
+
+    @pet = create(:pet)
+    create(:adopter_application, :successful_applicant, pet_id: @pet.id)
+
+    sign_in @user
+  end
+
+  context "adoption applications" do
+    should "should show list of user's adoption applications" do
+      visit adopter_fosterer_dashboard_index_path
+      click_on "Adoption Applications"
+      assert_text "this will fail"
+    end
+  end
+end

--- a/test/system/adoption_fosterer_test.rb
+++ b/test/system/adoption_fosterer_test.rb
@@ -3,14 +3,11 @@ require "application_system_test_case"
 class AdoptionFostererTest < ApplicationSystemTestCase
   setup do
     @user = create(:fosterer, :with_profile)
-    @adopter_foster_account = @user.adopter_foster_account
-
     @org = @user.organization
     @page_text = create(:page_text, :with_image, organization: @org)
-    Current.organization = @org
 
     @pet = create(:pet)
-    create(:adopter_application, pet: @pet, adopter_foster_account: @adopter_foster_account, organization: @org)
+    create(:adopter_application, pet: @pet, adopter_foster_account: @user.adopter_foster_account, organization: @org)
 
     sign_in @user
   end

--- a/test/system/adoption_fosterer_test.rb
+++ b/test/system/adoption_fosterer_test.rb
@@ -3,12 +3,14 @@ require "application_system_test_case"
 class AdoptionFostererTest < ApplicationSystemTestCase
   setup do
     @user = create(:fosterer, :with_profile)
-    @organization = @user.organization
-    @page_text = create(:page_text, :with_image, organization: @organization)
-    Current.organization = @organization
+    @adopter_foster_account = @user.adopter_foster_account
+
+    @org = @user.organization
+    @page_text = create(:page_text, :with_image, organization: @org)
+    Current.organization = @org
 
     @pet = create(:pet)
-    create(:adopter_application, :successful_applicant, pet_id: @pet.id)
+    create(:adopter_application, pet: @pet, adopter_foster_account: @adopter_foster_account, organization: @org)
 
     sign_in @user
   end
@@ -17,7 +19,21 @@ class AdoptionFostererTest < ApplicationSystemTestCase
     should "should show list of user's adoption applications" do
       visit adopter_fosterer_dashboard_index_path
       click_on "Adoption Applications"
-      assert_text "this will fail"
+      assert_text @pet.name
+    end
+
+    should "should let user withdraw and then delete applications from their list" do
+      visit adopter_fosterer_adopter_applications_path
+      assert_text @pet.name
+      assert_text "Under Review"
+      accept_confirm do
+        click_on "Withdraw Application"
+      end
+      assert_text "Withdrawn"
+      accept_confirm do
+        click_on "Delete"
+      end
+      assert_no_text @pet.name
     end
   end
 end

--- a/test/system/login_test.rb
+++ b/test/system/login_test.rb
@@ -21,4 +21,24 @@ class LoginTest < ApplicationSystemTestCase
       assert has_current_path?(staff_dashboard_index_path)
     end
   end
+
+  context "when logging in as a fosterer" do
+    setup do
+      @user = create(:fosterer, :with_profile)
+      @organization = @user.organization
+      @page_text = create(:page_text, :with_image, organization: @organization)
+      Current.organization = @organization
+    end
+
+    should "direct to the user's dashboard" do
+      visit root_url
+      click_on "Log In"
+
+      fill_in "Email", with: @user.email
+      fill_in "Password", with: @user.password
+      click_on "Log in"
+
+      assert has_current_path?(adopter_fosterer_dashboard_index_path)
+    end
+  end
 end


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/757

# ✍️ Description
Added a feature to the "adopter applications" page (the version that is part of the fosterer dashboard)
Now after an application is withdrawn via the "Withdraw Application" button, it is displayed with a "Delete" button which flags the application to no longer show in their list.

# 📷 Screenshots/Demos
I'm going to try to come back and do this later, I delayed making a PR after I finished this because I was going to take a screen recording, but I realized with a bunch of people working on the same codebase I should actually get my code in for everyone to see
