### PR TITLE
707 Dashboard metric for Incomplete and Overdue tasks

### DIFF
--- a/app/controllers/organizations/staff/dashboard_controller.rb
+++ b/app/controllers/organizations/staff/dashboard_controller.rb
@@ -12,7 +12,6 @@ class Organizations::Staff::DashboardController < Organizations::BaseController
   end
 
   def incomplete_tasks
-    @organization = Current.organization
     @pagy, @pets = pagy(
       Pet
       .left_joins(:tasks)
@@ -32,7 +31,6 @@ class Organizations::Staff::DashboardController < Organizations::BaseController
   end
 
   def overdue_tasks
-    @organization = Current.organization
     @pagy, @pets = pagy(
       Pet
       .left_joins(:tasks)

--- a/app/controllers/organizations/staff/dashboard_controller.rb
+++ b/app/controllers/organizations/staff/dashboard_controller.rb
@@ -5,6 +5,9 @@ class Organizations::Staff::DashboardController < Organizations::BaseController
     @user = current_user
     @organization = Current.organization
     @hide_footer = true
+    pet_ids = @organization.pets.pluck(:id)
+    @not_completed_not_overdue_tasks_count = Task.where(pet_id: pet_ids).is_not_completed.not_overdue.count
+    @not_completed_overdue_tasks_count = Task.where(pet_id: pet_ids).is_not_completed.overdue.count
 
     authorize! :dashboard, context: {organization: @organization}
   end

--- a/app/controllers/organizations/staff/dashboard_controller.rb
+++ b/app/controllers/organizations/staff/dashboard_controller.rb
@@ -17,18 +17,18 @@ class Organizations::Staff::DashboardController < Organizations::BaseController
     @pagy, @pets = pagy(
       @organization.pets
                    .left_joins(:tasks)
-                   .select('pets.*, COUNT(tasks.id) AS incomplete_tasks_count')
-                   .where(tasks: { completed: false })
-                   .where('tasks.due_date IS NULL OR tasks.due_date >= ?', Time.current)
-                   .group('pets.id'),
+                   .select("pets.*, COUNT(tasks.id) AS incomplete_tasks_count")
+                   .where(tasks: {completed: false})
+                   .where("tasks.due_date IS NULL OR tasks.due_date >= ?", Time.current)
+                   .group("pets.id"),
       items: 5
     )
     @column_name = "Incomplete Tasks"
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.replace("tasks-frame", partial: "organizations/staff/dashboard/tasks", locals: { column_name: @column_name })
+        render turbo_stream: turbo_stream.replace("tasks-frame", partial: "organizations/staff/dashboard/tasks", locals: {column_name: @column_name})
       end
-      format.html { render :tasks, locals: { column_name: @column_name } }
+      format.html { render :tasks, locals: {column_name: @column_name} }
     end
   end
 
@@ -37,22 +37,23 @@ class Organizations::Staff::DashboardController < Organizations::BaseController
     @pagy, @pets = pagy(
       @organization.pets
                    .left_joins(:tasks)
-                   .select('pets.*, COUNT(tasks.id) AS incomplete_tasks_count')
-                   .where(tasks: { completed: false })
-                   .where('tasks.due_date < ?', Time.current)
-                   .group('pets.id'),
+                   .select("pets.*, COUNT(tasks.id) AS incomplete_tasks_count")
+                   .where(tasks: {completed: false})
+                   .where("tasks.due_date < ?", Time.current)
+                   .group("pets.id"),
       items: 5
     )
     @column_name = "Overdue Tasks"
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.replace("tasks-frame", partial: "organizations/staff/dashboard/tasks", locals: { column_name: @column_name })
+        render turbo_stream: turbo_stream.replace("tasks-frame", partial: "organizations/staff/dashboard/tasks", locals: {column_name: @column_name})
       end
-      format.html { render :tasks, locals: { column_name: @column_name } }
+      format.html { render :tasks, locals: {column_name: @column_name} }
     end
   end
 
   private
+
   def context_authorize!
     authorize! :dashboard,
       context: {organization: Current.organization}

--- a/app/controllers/organizations/staff/dashboard_controller.rb
+++ b/app/controllers/organizations/staff/dashboard_controller.rb
@@ -7,20 +7,19 @@ class Organizations::Staff::DashboardController < Organizations::BaseController
     @user = current_user
     @organization = Current.organization
     @hide_footer = true
-    pet_ids = @organization.pets.pluck(:id)
-    @not_completed_not_overdue_tasks_count = Task.where(pet_id: pet_ids).is_not_completed.not_overdue.count
-    @not_completed_overdue_tasks_count = Task.where(pet_id: pet_ids).is_not_completed.overdue.count
+    @not_completed_not_overdue_tasks_count = Task.is_not_completed.not_overdue.count
+    @not_completed_overdue_tasks_count = Task.is_not_completed.overdue.count
   end
 
   def incomplete_tasks
     @organization = Current.organization
     @pagy, @pets = pagy(
-      @organization.pets
-                   .left_joins(:tasks)
-                   .select("pets.*, COUNT(tasks.id) AS incomplete_tasks_count")
-                   .where(tasks: {completed: false})
-                   .where("tasks.due_date IS NULL OR tasks.due_date >= ?", Time.current)
-                   .group("pets.id"),
+      Pet
+      .left_joins(:tasks)
+      .select("pets.*, COUNT(tasks.id) AS incomplete_tasks_count")
+      .where(tasks: {completed: false})
+      .where("tasks.due_date IS NULL OR tasks.due_date >= ?", Time.current)
+      .group("pets.id"),
       items: 5
     )
     @column_name = "Incomplete Tasks"
@@ -35,12 +34,12 @@ class Organizations::Staff::DashboardController < Organizations::BaseController
   def overdue_tasks
     @organization = Current.organization
     @pagy, @pets = pagy(
-      @organization.pets
-                   .left_joins(:tasks)
-                   .select("pets.*, COUNT(tasks.id) AS incomplete_tasks_count")
-                   .where(tasks: {completed: false})
-                   .where("tasks.due_date < ?", Time.current)
-                   .group("pets.id"),
+      Pet
+      .left_joins(:tasks)
+      .select("pets.*, COUNT(tasks.id) AS incomplete_tasks_count")
+      .where(tasks: {completed: false})
+      .where("tasks.due_date < ?", Time.current)
+      .group("pets.id"),
       items: 5
     )
     @column_name = "Overdue Tasks"

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -36,6 +36,9 @@ class Task < ApplicationRecord
   scope :is_completed, -> { where(completed: true) }
   scope :has_due_date, -> { where.not(due_date: nil).order(due_date: :asc) }
   scope :no_due_date, -> { where(due_date: nil).order(updated_at: :desc) }
+  scope :not_overdue, -> { where('(due_date >= ? OR due_date IS NULL)', Time.current) }
+  scope :overdue, -> { where('(due_date < ? )', Time.current) }
+
 
   def overdue?
     due_date_passed? && !completed

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -36,9 +36,8 @@ class Task < ApplicationRecord
   scope :is_completed, -> { where(completed: true) }
   scope :has_due_date, -> { where.not(due_date: nil).order(due_date: :asc) }
   scope :no_due_date, -> { where(due_date: nil).order(updated_at: :desc) }
-  scope :not_overdue, -> { where('(due_date >= ? OR due_date IS NULL)', Time.current) }
-  scope :overdue, -> { where('(due_date < ? )', Time.current) }
-
+  scope :not_overdue, -> { where("(due_date >= ? OR due_date IS NULL)", Time.current) }
+  scope :overdue, -> { where("(due_date < ? )", Time.current) }
 
   def overdue?
     due_date_passed? && !completed

--- a/app/policies/organizations/dashboard_policy.rb
+++ b/app/policies/organizations/dashboard_policy.rb
@@ -9,4 +9,8 @@ class Organizations::DashboardPolicy < ApplicationPolicy
   def incomplete_tasks?
     permission?(:view_organization_dashboard)
   end
+
+  def overdue_tasks?
+    permission?(:view_organization_dashboard)
+  end
 end

--- a/app/policies/organizations/dashboard_policy.rb
+++ b/app/policies/organizations/dashboard_policy.rb
@@ -5,4 +5,8 @@ class Organizations::DashboardPolicy < ApplicationPolicy
   def index?
     permission?(:view_organization_dashboard)
   end
+
+  def incomplete_tasks?
+    permission?(:view_organization_dashboard)
+  end
 end

--- a/app/views/organizations/staff/dashboard/incomplete_tasks.html.erb
+++ b/app/views/organizations/staff/dashboard/incomplete_tasks.html.erb
@@ -3,26 +3,23 @@
     <table class="table mb-0 text-nowrap table-hover table-centered">
       <thead>
         <tr>
-          <th scope="col">Image</th>
           <th scope="col">Name</th>
-          <th scope="col">Sex</th>
-          <th scope="col">Number of Incomplete Tasks</th>
+          <th class="text-center" scope="col">Sex</th>
+          <th class="text-center" scope="col">Number of Incomplete Tasks</th>
         </tr>
       </thead>
       <tbody>
         <% @pets.each do |pet| %>
           <tr>
             <td>
-              <div class="icon-shape icon-lg rounded-3 border">
-                <% if pet.images.attached? %>
-                  <%= image_tag pet.images.first, class: 'card-img' %>
-                <% else %>
-                  <%= image_tag('coming_soon.jpg', class: 'card-img') %>
-                <% end %>
-              </div>
-            </td>
-            <td>
               <div class="d-flex align-items-center">
+                <div class="icon-shape icon-lg rounded-3 border">
+                  <% if pet.images.attached? %>
+                    <%= image_tag pet.images.first, class: 'card-img' %>
+                  <% else %>
+                    <%= image_tag('coming_soon.jpg', class: 'card-img') %>
+                  <% end %>
+                </div>
                 <div class="ms-3">
                   <h4 class="mb-0">
                     <%= link_to pet.name, staff_pet_path(pet), class: 'text-inherit', data: { turbo: false } %>
@@ -30,11 +27,15 @@
                 </div>
               </div>
             </td>
-            <td>
-              <%= pet.sex %>
+             <td>
+              <div class="d-flex justify-content-center">
+                <%= pet.sex %>
+              </div>
             </td>
             <td>
-              <%= pet.incomplete_tasks_count %>
+              <div class="d-flex justify-content-center">
+                <%= link_to pet.incomplete_tasks_count, staff_pet_path(pet, active_tab: 'tasks'), class: 'text-inherit', data: { turbo: false } %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/organizations/staff/dashboard/incomplete_tasks.html.erb
+++ b/app/views/organizations/staff/dashboard/incomplete_tasks.html.erb
@@ -1,0 +1,47 @@
+<turbo-frame id="tasks-frame">
+  <div class="card">
+    <table class="table mb-0 text-nowrap table-hover table-centered">
+      <thead>
+        <tr>
+          <th scope="col">Image</th>
+          <th scope="col">Name</th>
+          <th scope="col">Sex</th>
+          <th scope="col">Number of Incomplete Tasks</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @pets.each do |pet| %>
+          <tr>
+            <td>
+              <div class="icon-shape icon-lg rounded-3 border">
+                <% if pet.images.attached? %>
+                  <%= image_tag pet.images.first, class: 'card-img' %>
+                <% else %>
+                  <%= image_tag('coming_soon.jpg', class: 'card-img') %>
+                <% end %>
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                <div class="ms-3">
+                  <h4 class="mb-0">
+                    <%= link_to pet.name, staff_pet_path(pet), class: 'text-inherit', data: { turbo: false } %>
+                  </h4>
+                </div>
+              </div>
+            </td>
+            <td>
+              <%= pet.sex %>
+            </td>
+            <td>
+              <%= pet.incomplete_tasks_count %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <div class="d-flex justify-content-center align-items-center mt-2">
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+  </div>
+</turbo-frame>

--- a/app/views/organizations/staff/dashboard/index.html.erb
+++ b/app/views/organizations/staff/dashboard/index.html.erb
@@ -9,7 +9,7 @@
           <% c.icon "list" %>
           <% c.value do %>
             <div>
-              <div> <%= link_to "#{@not_completed_not_overdue_tasks_count} Pending", incomplete_tasks_staff_dashboard_index_path, data: { turbo_frame: "tasks-frame" } %> </div>
+              <div> <%= link_to "#{@not_completed_not_overdue_tasks_count} Incomplete", incomplete_tasks_staff_dashboard_index_path, data: { turbo_frame: "tasks-frame" } %> </div>
               <div> <%= link_to "#{@not_completed_overdue_tasks_count} Overdue", overdue_tasks_staff_dashboard_index_path, data: { turbo_frame: "tasks-frame" } %> </div>
             </div>
           <% end %>

--- a/app/views/organizations/staff/dashboard/index.html.erb
+++ b/app/views/organizations/staff/dashboard/index.html.erb
@@ -10,7 +10,7 @@
           <% c.value do %>
             <div>
               <div> <%= link_to "#{@not_completed_not_overdue_tasks_count} Pending", incomplete_tasks_staff_dashboard_index_path, data: { turbo_frame: "tasks-frame" } %> </div>
-              <div> <%= link_to "#{@not_completed_overdue_tasks_count} Overdue", "" %> </div>
+              <div> <%= link_to "#{@not_completed_overdue_tasks_count} Overdue", overdue_tasks_staff_dashboard_index_path, data: { turbo_frame: "tasks-frame" } %> </div>
             </div>
           <% end %>
         <% end %>

--- a/app/views/organizations/staff/dashboard/index.html.erb
+++ b/app/views/organizations/staff/dashboard/index.html.erb
@@ -5,9 +5,14 @@
     <div class="row">
       <div class="col-xl-3 col-lg-6 col-md-12 col-12">
         <%= render "components/data_card" do |c| %>
-          <% c.title "Staff" %>
-          <% c.icon "users" %>
-          <% c.value @organization.staff_accounts.count %>
+          <% c.title "Tasks" %>
+          <% c.icon "list" %>
+          <% c.value do %>
+            <div>
+              <div> <%= link_to "#{@organization.staff_accounts.count} Not Completed", "" %> </div>
+              <div> <%= link_to "#{@organization.staff_accounts.count} Overdue", "" %> </div>
+            </div>
+          <% end %>
         <% end %>
       </div>
       <div class="col-xl-3 col-lg-6 col-md-12 col-12">

--- a/app/views/organizations/staff/dashboard/index.html.erb
+++ b/app/views/organizations/staff/dashboard/index.html.erb
@@ -9,7 +9,7 @@
           <% c.icon "list" %>
           <% c.value do %>
             <div>
-              <div> <%= link_to "#{@not_completed_not_overdue_tasks_count} Not Completed", "" %> </div>
+              <div> <%= link_to "#{@not_completed_not_overdue_tasks_count} Pending", incomplete_tasks_staff_dashboard_index_path, data: { turbo_frame: "tasks-frame" } %> </div>
               <div> <%= link_to "#{@not_completed_overdue_tasks_count} Overdue", "" %> </div>
             </div>
           <% end %>
@@ -39,5 +39,7 @@
         <% end %>
       </div>
     </div>
+    
+    <%= turbo_frame_tag "tasks-frame" %>
   <% end %>
 <% end %>

--- a/app/views/organizations/staff/dashboard/index.html.erb
+++ b/app/views/organizations/staff/dashboard/index.html.erb
@@ -9,8 +9,8 @@
           <% c.icon "list" %>
           <% c.value do %>
             <div>
-              <div> <%= link_to "#{@organization.staff_accounts.count} Not Completed", "" %> </div>
-              <div> <%= link_to "#{@organization.staff_accounts.count} Overdue", "" %> </div>
+              <div> <%= link_to "#{@not_completed_not_overdue_tasks_count} Not Completed", "" %> </div>
+              <div> <%= link_to "#{@not_completed_overdue_tasks_count} Overdue", "" %> </div>
             </div>
           <% end %>
         <% end %>

--- a/app/views/organizations/staff/dashboard/tasks.html.erb
+++ b/app/views/organizations/staff/dashboard/tasks.html.erb
@@ -5,7 +5,7 @@
         <tr>
           <th scope="col">Name</th>
           <th class="text-center" scope="col">Sex</th>
-          <th class="text-center" scope="col">Number of Incomplete Tasks</th>
+          <th class="text-center" scope="col"><%= column_name %></th>
         </tr>
       </thead>
       <tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,12 @@ Rails.application.routes.draw do
 
       resources :default_pet_tasks
       resources :faqs
-      resources :dashboard, only: [:index]
+      resources :dashboard, only: [:index] do
+        collection do
+          get :incomplete_tasks
+          get :overdue_tasks
+        end
+      end
       resources :matches, only: %i[create destroy]
 
       resources :adoption_application_reviews, only: %i[index edit update]

--- a/test/controllers/organizations/staff/dashboard_controller_test.rb
+++ b/test/controllers/organizations/staff/dashboard_controller_test.rb
@@ -23,5 +23,41 @@ class Organizations::Staff::DashboardControllerTest < ActionDispatch::Integratio
         end
       end
     end
+
+    context "#incomplete_tasks" do
+      should "be authorized" do
+        assert_authorized_to(
+          :incomplete_tasks?, :dashboard,
+          context: {organization: @organization},
+          with: Organizations::DashboardPolicy
+        ) do
+          get incomplete_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+        end
+      end
+
+      should "return turbo_stream response" do
+        get incomplete_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+        assert_response :success
+        assert_match "tasks-frame", response.body
+      end
+    end
+
+    context "#overdue_tasks" do
+      should "be authorized" do
+        assert_authorized_to(
+          :overdue_tasks?, :dashboard,
+          context: {organization: @organization},
+          with: Organizations::DashboardPolicy
+        ) do
+          get overdue_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+        end
+      end
+
+      should "return turbo_stream response" do
+        get overdue_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+        assert_response :success
+        assert_match "tasks-frame", response.body
+      end
+    end
   end
 end

--- a/test/controllers/organizations/staff/dashboard_controller_test.rb
+++ b/test/controllers/organizations/staff/dashboard_controller_test.rb
@@ -31,12 +31,12 @@ class Organizations::Staff::DashboardControllerTest < ActionDispatch::Integratio
           context: {organization: @organization},
           with: Organizations::DashboardPolicy
         ) do
-          get incomplete_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+          get incomplete_tasks_staff_dashboard_index_url, headers: {"Turbo-Frame" => "tasks-frame"}
         end
       end
 
       should "return turbo_stream response" do
-        get incomplete_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+        get incomplete_tasks_staff_dashboard_index_url, headers: {"Turbo-Frame" => "tasks-frame"}
         assert_response :success
         assert_match "tasks-frame", response.body
       end
@@ -49,12 +49,12 @@ class Organizations::Staff::DashboardControllerTest < ActionDispatch::Integratio
           context: {organization: @organization},
           with: Organizations::DashboardPolicy
         ) do
-          get overdue_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+          get overdue_tasks_staff_dashboard_index_url, headers: {"Turbo-Frame" => "tasks-frame"}
         end
       end
 
       should "return turbo_stream response" do
-        get overdue_tasks_staff_dashboard_index_url, headers: { "Turbo-Frame" => "tasks-frame" }
+        get overdue_tasks_staff_dashboard_index_url, headers: {"Turbo-Frame" => "tasks-frame"}
         assert_response :success
         assert_match "tasks-frame", response.body
       end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -68,4 +68,30 @@ class TaskTest < ActiveSupport::TestCase
     assert_equal([task2, task6, task5, task4, task3, task1], [list[0], list[1], list[2], list[3], list[4], list[5]])
   end
   should validate_numericality_of(:next_due_date_in_days).only_integer.allow_nil
+
+  test "not_overdue scope should return tasks that are not overdue" do
+    pet = build(:pet)
+    overdue_task = create(:task, pet: pet, due_date: 1.day.ago)
+    not_overdue_task_with_due_date = create(:task, pet: pet, due_date: 1.day.from_now)
+    not_overdue_task_without_due_date = create(:task, pet: pet, due_date: nil)
+
+    not_overdue_tasks = Task.not_overdue
+
+    assert_includes not_overdue_tasks, not_overdue_task_with_due_date
+    assert_includes not_overdue_tasks, not_overdue_task_without_due_date
+    refute_includes not_overdue_tasks, overdue_task
+  end
+
+  test "overdue scope should return tasks that are overdue" do
+    pet = build(:pet)
+    overdue_task = create(:task, pet: pet, due_date: 1.day.ago)
+    not_overdue_task_with_due_date = create(:task, pet: pet, due_date: 1.day.from_now)
+    not_overdue_task_without_due_date = create(:task, pet: pet, due_date: nil)
+
+    overdue_tasks = Task.overdue
+
+    assert_includes overdue_tasks, overdue_task
+    refute_includes overdue_tasks, not_overdue_task_with_due_date
+    refute_includes overdue_tasks, not_overdue_task_without_due_date
+  end
 end

--- a/test/system/dashboard_test.rb
+++ b/test/system/dashboard_test.rb
@@ -17,7 +17,7 @@ class DashboardTest < ApplicationSystemTestCase
   end
 
   test "viewing incomplete tasks" do
-    click_link "Pending"
+    click_link "Incomplete"
     assert_selector "table"
     assert_text "Incomplete Tasks"
 

--- a/test/system/dashboard_test.rb
+++ b/test/system/dashboard_test.rb
@@ -1,0 +1,44 @@
+require "application_system_test_case"
+
+class DashboardTest < ApplicationSystemTestCase
+  setup do
+    @user = create(:staff)
+    @organization = @user.organization
+    Current.organization = @organization
+    @pets = create_list(:pet, 3, organization: @organization)
+
+    @pets.each do |pet|
+      create_list(:task, 2, pet: pet, completed: false, due_date: nil)
+      create_list(:task, 1, pet: pet, completed: false, due_date: 2.days.ago)
+    end
+
+    sign_in @user
+    visit staff_dashboard_index_path
+  end
+
+  test "viewing incomplete tasks" do
+    click_link "Pending"
+    assert_selector "table"
+    assert_text "Incomplete Tasks"
+
+    within "table" do
+      @pets.each do |pet|
+        assert_text pet.name
+        assert_text "2"
+      end
+    end
+  end
+
+  test "viewing overdue tasks" do
+    click_link "Overdue"
+    assert_selector "table"
+    assert_text "Overdue Tasks"
+
+    within "table" do
+      @pets.each do |pet|
+        assert_text pet.name
+        assert_text "1"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 🔗 Issue
#707 

# ✍️ Description
- Added new scopes in task model to get not_overdue and overdue tasks
- Updated Dashboard controller index method to calculate number of incomplete and overdue tasks in organization
- Added two new methods in dashboard controller to fetch for each pet number of incomplete and overdue tasks
- In dashboard index view, added metric to display pending and over tasks counts
- On click of each metric, we render pet table details using turbo frame

# 📷 Screenshots/Demos

Dashboard Page

![Alta-Pet-Rescue-Pet-Rescue-dashboard](https://github.com/rubyforgood/pet-rescue/assets/514363/4e5e7c43-dd7f-4b46-8f5a-422be8932b4a)


Dashboard Page with Incomplete Tasks

![Alta-Pet-Rescue-Pet-Rescue-dashboard-pending-tasks](https://github.com/rubyforgood/pet-rescue/assets/514363/925c54ac-f89d-4825-bd63-d59191353b22)

Dashboard Page with Overdue Tasks

![Alta-Pet-Rescue-Pet-Rescue-dashboard-overdue-tasks](https://github.com/rubyforgood/pet-rescue/assets/514363/1ca2834a-12ea-4a2f-a513-c625a1b3b61b)

