### PR TITLE
737 add missing translations

### DIFF
--- a/app/views/organizations/adopter_fosterer/profiles/show.html.erb
+++ b/app/views/organizations/adopter_fosterer/profiles/show.html.erb
@@ -121,9 +121,9 @@
               <strong><%= t('.will_petcare_be_shared') %></strong>
             </p>
             <% if @adopter_foster_profile.shared_ownership %>
-              <p class="col-lg-6 text-muted"><%= t('.general.yes') %></p>
+              <p class="col-lg-6 text-muted"><%= t('general.yes') %></p>
             <% else %>
-              <p class="col-lg-6 text-muted"><%= t('.general.no') %></p>
+              <p class="col-lg-6 text-muted"><%= t('general.no') %></p>
             <% end %>
           </div>
 
@@ -142,13 +142,13 @@
           <hr>
           <h4 class="mb-4 mt-4"><%= t('.household') %>></h4>
           <div class="row mb-3 bigger">
-            <p class="col-lg-4"><strong><%= t('.Housing type') %></strong></p>
+            <p class="col-lg-4"><strong><%= t('.housing_type') %></strong></p>
             <p class="col-lg-6 text-muted">
               <%= @adopter_foster_profile.housing_type %>
             </p>
           </div>
           <div class="row mb-3 bigger">
-            <p class="col-lg-4"><strong><%= t('.Do you have access to a fenced garden?') %></strong></p>
+            <p class="col-lg-4"><strong><%= t('.fenced_access_question') %></strong></p>
             <% if @adopter_foster_profile.fenced_access %>
               <p class="col-lg-6 text-muted"><%= t('general.yes') %></p>
             <% else %>
@@ -177,7 +177,7 @@
           </div>
 
           <div class="row mb-3 bigger">
-            <p class="col-lg-4"><strong><%= t('.Do you rent your home or live on a strata property?') %></strong></p>
+            <p class="col-lg-4"><strong><%= t('.rent_question') %></strong></p>
             <% if @adopter_foster_profile.do_you_rent %>
             <p class="col-lg-6 text-muted"><%= t('general.yes') %></p>
             <% else %>
@@ -195,13 +195,13 @@
           </div>
           <% end %>
           <div class="row mb-3 bigger">
-            <p class="col-lg-4"><strong><%= t('.Number of adults in home (over 18)') %></strong></p>
+            <p class="col-lg-4"><strong><%= t('.adults_in_home') %></strong></p>
             <p class="col-lg-6 text-muted">
               <%= @adopter_foster_profile.adults_in_home %>
             </p>
           </div>
           <div class="row mb-3 bigger">
-            <p class="col-lg-4"><strong><%= t('.Number of children in home (under 18)') %></strong></p>
+            <p class="col-lg-4"><strong><%= t('.children_in_home') %></strong></p>
             <% if @adopter_foster_profile.kids_in_home == 0 %>
             <p class="col-lg-6 text-muted"><%= t('general.none') %></p>
             <% else %>
@@ -211,7 +211,7 @@
             <% end %>
           </div>
           <div class="row mb-3 bigger">
-            <p class="col-lg-4"><strong><%= t('.Do you have pets in your home?') %></strong></p>
+            <p class="col-lg-4"><strong><%= t('.pets_in_home') %></strong></p>
             <% if @adopter_foster_profile.other_pets %>
             <p class="col-lg-6 text-muted"><%= t('general.yes') %></p>
             <% else %>
@@ -220,7 +220,7 @@
           </div>
           <% if @adopter_foster_profile.other_pets %>
             <div class="row mb-4 bigger">
-              <p class="col-lg-4"><strong><%= t('.Description of pets') %></strong></p>
+              <p class="col-lg-4"><strong><%= t('.describe_pets') %></strong></p>
               <p class="col-lg-6 text-muted" style="white-space: pre-line;">
                 <%= @adopter_foster_profile.describe_pets %>
               </p>

--- a/app/views/organizations/staff/pets/tabs/_overview.html.erb
+++ b/app/views/organizations/staff/pets/tabs/_overview.html.erb
@@ -46,12 +46,12 @@
               </td>
               <td>
                 <p class="text-dark mb-0 fw-semibold">
-                  <%= @pet.application_paused == false ? t('.application.active') : t('.application.paused') %>
+                  <%= @pet.application_paused == false ? t('.status.active') : t('.status.paused') %>
                 </p>
               </td>
               <td>
                 <p class="text-dark mb-0 fw-semibold">
-                  <%= @pet.published == true ? t('.published.published') : t('.published.draft') %>
+                  <%= @pet.published == true ? t('.status.published') : t('.status.draft') %>
                 </p>
               </td>
             <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,6 +362,14 @@ en:
           under_review: "Under Review"
           adoption_pending: "Adoption Pending"
           withdrawn: "Withdrawn"
+          successful_applicant: "Successful Applicant"
+        tabs:
+          overview:
+            status:
+              active: "Active"
+              paused: "Paused"
+              published: "Published"
+              draft: "Draft"
       forms:
         not_found: "Form not found."
         index:
@@ -376,6 +384,7 @@ en:
           edit_form: "Edit Form"
         show:
           confirm_delete_question: "Are you sure you want to delete this question?"
+          create_question: "Create Question"
         update:
         destroy:
         form:
@@ -386,6 +395,8 @@ en:
         updated: "Form saved successfully."
         destroyed: "Form was successfully deleted."
       questions:
+        new:
+          new_question: "New Question"
         create:
           error: "Error creating question."
         update:
@@ -394,6 +405,12 @@ en:
         saved: "Question saved successfully."
         destroyed: "Question was successfully deleted."
         not_found: "Question not found."
+        edit:
+          edit_question: "Edit Question"
+        form:
+          help_text:
+            label: "Label"
+            help_text: "help text"
     adopter_fosterer:
       profiles:
         form:
@@ -405,6 +422,13 @@ en:
           adopter_foster_profile: "Adopter Foster Profile"
           help_us_learn_more: "The following questions help us learn more about you so we can match you with the right pooch."
         show:
+          describe_pets: "Description of pets"
+          adults_in_home: "Number of adults in home (over 18)"
+          children_in_home: "Number of children in home (under 18)"
+          pets_in_home: "¿Do you have pets in your home?"
+          rent_question: "¿Do you rent your home or live on a strata property?"
+          fenced_access_question: "¿Do you have access to a fenced garden?"
+          housing_type: "Housing Type"
           adopter_foster_profile: "Adopter Foster Profile"
           edit_profile: "Edit Profile"
           your_ideal_pet: "Your ideal pet"


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
https://github.com/rubyforgood/pet-rescue/issues/737
# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

1. Sets I18n test and dev config to raise errors on missing translations.
2. Add all missing translations.
3. Fixes wrong lookups of translations.



# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

##  With new config when we miss a translation on a view it will look like this (development):
![image](https://github.com/rubyforgood/pet-rescue/assets/55507343/0b3dcc3d-340a-415c-9872-675017e103d1)

## app/views/organizations/staff/pets/tabs/_overview.html.erb with added translations.

![image](https://github.com/rubyforgood/pet-rescue/assets/55507343/616d6b02-c669-4a2d-bf00-bcc7e29e134c)
