### PR TITLE
Disable deactivate toggle if account is current user

### DIFF
--- a/app/views/organizations/staff/staff/_deactivate_toggle.html.erb
+++ b/app/views/organizations/staff/staff/_deactivate_toggle.html.erb
@@ -3,7 +3,7 @@
     <div class='form-group d-flex justify-content-center'>
       <div class="form-check form-switch">
         <%= form.check_box :deactivated?,{ class: "form-check-input",
-        role: "switch", id: "flexSwitchCheckChecked", onchange: "this.form.requestSubmit()"}, true, false %>
+        role: "switch", disabled: staff == current_user.staff_account, id: "flexSwitchCheckChecked", onchange: "this.form.requestSubmit()"}, true, false %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
Resolves #804 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Deactivate toggle is disabled for the current user's account

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
[Screencast from 06-03-2024 08:53:08 PM.webm](https://github.com/rubyforgood/pet-rescue/assets/16829344/62818658-1a42-4599-ba4e-44207f279390)

