### PR TITLE
Generate a person model

### DIFF
--- a/app/models/concerns/avatarable.rb
+++ b/app/models/concerns/avatarable.rb
@@ -4,6 +4,7 @@ module Avatarable
   included do
     has_one_attached :avatar
 
+    # TODO:  move these validation strings to a locale file
     validates :avatar, content_type: {in: ["image/png", "image/jpeg"],
                                       message: "must be PNG or JPEG"},
       size: {between: 10.kilobyte..1.megabytes,

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: people
+#
+#  id              :bigint           not null, primary key
+#  email           :string           not null
+#  name            :string           not null
+#  phone           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  organization_id :bigint           not null
+#
+# Indexes
+#
+#  index_people_on_email            (email)
+#  index_people_on_organization_id  (organization_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (organization_id => organizations.id)
+#
+class Person < ApplicationRecord
+  include Avatarable
+
+  acts_as_tenant(:organization)
+
+  validates :name, presence: true
+  validates :email, presence: true,
+    uniqueness: {case_sensitive: false, scope: :organization_id}
+end

--- a/db/migrate/20240609170030_create_people.rb
+++ b/db/migrate/20240609170030_create_people.rb
@@ -1,0 +1,12 @@
+class CreatePeople < ActiveRecord::Migration[7.1]
+  def change
+    create_table :people do |t|
+      t.references :organization, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :email, null: false, index: true
+      t.string :phone
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_22_160107) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_09_170030) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -230,6 +230,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_160107) do
     t.index ["organization_id"], name: "index_page_texts_on_organization_id"
   end
 
+  create_table "people", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "phone"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_people_on_email"
+    t.index ["organization_id"], name: "index_people_on_organization_id"
+  end
+
   create_table "pets", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.datetime "created_at", null: false
@@ -359,6 +370,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_22_160107) do
   add_foreign_key "organization_profiles", "locations"
   add_foreign_key "organization_profiles", "organizations"
   add_foreign_key "page_texts", "organizations"
+  add_foreign_key "people", "organizations"
   add_foreign_key "pets", "organizations"
   add_foreign_key "questions", "forms"
   add_foreign_key "staff_accounts", "organizations"

--- a/test/factories/people.rb
+++ b/test/factories/people.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :person do
+    organization
+
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+
+    trait :with_phone do
+      phone { Faker::PhoneNumber.phone_number }
+    end
+  end
+end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class PersonTest < ActiveSupport::TestCase
+  context "validations" do
+    should validate_presence_of(:name)
+    should validate_presence_of(:email)
+    should_not validate_presence_of(:phone)
+  end
+
+  context "database validations" do
+    subject { create(:person, organization: create(:organization)) }
+
+    # FIXME `shoulda-matchers` is throwing an error here:
+    # NoMethodError: undefined method `keys' for an instance of ActiveModel::Errors
+    #
+    # should validate_uniqueness_of(:email)
+    #   .case_insensitive
+    #   .scoped_to(:organization_id)
+  end
+
+  context "#avatar" do
+    should "attach an avatar" do
+      file = load_file("test.png")
+
+      assert_nothing_raised do
+        subject.avatar.attach(io: file, filename: "test.png")
+      end
+    end
+
+    context "validations" do
+      should "error if the avatar is too big" do
+        file = load_file("test.png")
+        file.stubs(:size).returns(5.megabytes)
+
+        subject.avatar.attach(io: file, filename: "test.png")
+
+        refute subject.valid?
+        assert_includes subject.errors[:avatar], "size must be between 10kb and 1Mb"
+      end
+
+      should "error if the avatar is too small" do
+        file = load_file("test.png")
+        file.stubs(:size).returns(5.kilobytes)
+
+        subject.avatar.attach(io: file, filename: "test.png")
+
+        refute subject.valid?
+        assert_includes subject.errors[:avatar], "size must be between 10kb and 1Mb"
+      end
+
+      should "error if the avatar is not an image" do
+        file = load_file("blank.pdf")
+
+        subject.avatar.attach(io: file, filename: "test.png")
+
+        refute subject.valid?
+        assert_includes subject.errors[:avatar], "must be PNG or JPEG"
+      end
+    end
+  end
+
+  context "factories" do
+    should "generate a valid person" do
+      assert build(:person).valid?
+    end
+  end
+
+  def load_file(file_name)
+    File.open Rails.root.join("test/fixtures/files", file_name)
+  end
+end


### PR DESCRIPTION
# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

A person represents a flesh-and-blood human in the system, and should be
the core data model representing _most_ actors in the system.

Eventually, we will want to attach the filled form results to a person
record, and Accounts should belong to a person to grant the ability to
log into the system.

Note that this table explicitly does _not_ include any authentication
related material.  tokens generated for things like magic login, or
authorization credentials for regular users, should exist in their own
dedicated classes.  I'll follow up with an email+token based auth flow
implementation later.
