### PR TITLE
Update deprecated Action Dispatch variable value

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
# 🔗 Issue
#830

# ✍️ Description
Simple fix for a deprecated Action Dispatch setting value. This was being reported in the test results.
