### PR TITLE
Changes for renaming answer to CustomForm::SubmittedAnswer

### DIFF
--- a/app/models/custom_form/submitted_answer.rb
+++ b/app/models/custom_form/submitted_answer.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: answers
+# Table name: submitted_answers
 #
 #  id                :bigint           not null, primary key
 #  question_snapshot :json             not null
@@ -12,18 +12,20 @@
 #
 # Indexes
 #
-#  index_answers_on_question_id  (question_id)
-#  index_answers_on_user_id      (user_id)
+#  index_submitted_answers_on_question_id  (question_id)
+#  index_submitted_answers_on_user_id      (user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (question_id => questions.id)
 #  fk_rails_...  (user_id => users.id)
 #
-class Answer < ApplicationRecord
-  belongs_to :question
-  belongs_to :user
+module CustomForm
+  class SubmittedAnswer < ApplicationRecord
+    belongs_to :question
+    belongs_to :user
 
-  has_one :form, through: :question
-  has_one :organization, through: :form
+    has_one :form, through: :question
+    has_one :organization, through: :form
+  end
 end

--- a/db/migrate/20240619203450_rename_answers_to_submitted_answers.rb
+++ b/db/migrate/20240619203450_rename_answers_to_submitted_answers.rb
@@ -1,0 +1,5 @@
+class RenameAnswersToSubmittedAnswers < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :answers, :submitted_answers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_10_194826) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_19_203450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -92,17 +92,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_194826) do
     t.index ["adopter_foster_account_id"], name: "index_adopter_foster_profiles_on_adopter_foster_account_id", unique: true
     t.index ["location_id"], name: "index_adopter_foster_profiles_on_location_id"
     t.index ["organization_id"], name: "index_adopter_foster_profiles_on_organization_id"
-  end
-
-  create_table "answers", force: :cascade do |t|
-    t.json "value", null: false
-    t.json "question_snapshot", null: false
-    t.bigint "question_id", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["question_id"], name: "index_answers_on_question_id"
-    t.index ["user_id"], name: "index_answers_on_user_id"
   end
 
   create_table "default_pet_tasks", force: :cascade do |t|
@@ -298,6 +287,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_194826) do
     t.index ["pet_id"], name: "index_submissions_on_pet_id"
   end
 
+  create_table "submitted_answers", force: :cascade do |t|
+    t.json "value", null: false
+    t.json "question_snapshot", null: false
+    t.bigint "question_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id"], name: "index_submitted_answers_on_question_id"
+    t.index ["user_id"], name: "index_submitted_answers_on_user_id"
+  end
+
   create_table "tasks", force: :cascade do |t|
     t.string "name", null: false
     t.text "description"
@@ -354,8 +354,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_194826) do
   add_foreign_key "adopter_foster_accounts", "users"
   add_foreign_key "adopter_foster_profiles", "adopter_foster_accounts"
   add_foreign_key "adopter_foster_profiles", "locations"
-  add_foreign_key "answers", "questions"
-  add_foreign_key "answers", "users"
   add_foreign_key "default_pet_tasks", "organizations"
   add_foreign_key "faqs", "organizations"
   add_foreign_key "form_profiles", "forms"
@@ -375,5 +373,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_194826) do
   add_foreign_key "staff_accounts", "users"
   add_foreign_key "submissions", "adopter_foster_accounts"
   add_foreign_key "submissions", "pets"
+  add_foreign_key "submitted_answers", "questions"
+  add_foreign_key "submitted_answers", "users"
   add_foreign_key "tasks", "pets"
 end

--- a/test/factories/custom_form/submitted_answers.rb
+++ b/test/factories/custom_form/submitted_answers.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :answer do
+  factory :submitted_answer, class: "custom_form/submitted_answer" do
     value { JSON.dump Faker::Lorem.sentence }
     question_snapshot { question.snapshot }
     question

--- a/test/models/custom_form/submitted_answer_test.rb
+++ b/test/models/custom_form/submitted_answer_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class AnswerTest < ActiveSupport::TestCase
+class CustomForm::SubmittedAnswerTest < ActiveSupport::TestCase
   context "associations" do
     should belong_to(:question)
     should belong_to(:user)


### PR DESCRIPTION
# 🔗 Issue
#833 

# ✍️ Description

Rename answer to CustomForm::SubmittedAnswer throughout the application.

- Added new migration to rename answer to submitted_answers
- Nested answers model under CustomForm and renamed it to submitted_answer
- Annotated model with updated details
- Updated test file to match with nested module and updated name.


# 📷 Screenshots/Demos
NA
