### PR TITLE
Bug Fix

### DIFF
--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -102,8 +102,8 @@
                 <% else %>
                   <% if AdopterApplication.adoption_exists?(current_user.adopter_foster_account&.id, @pet.id) %>
                     <div class='d-flex align-items-center mt-3'>
-                      <h4 class="me-2">
-                        <%= "#{@adoption_application.human_enum_name(@adoption_application.status) || t('.status.default')}" %>
+                      <h4 class="me-2 mb-0">
+                        <%= "Application Status: #{@adoption_application.human_enum_name(:status) || t('.status.default')}" %>
                       </h4>
                       <% if %w[under_review adoption_pending].include?(@adoption_application.status) %>
                         <%= image_tag('pause.png', height: '21') %>

--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -103,7 +103,7 @@
                   <% if AdopterApplication.adoption_exists?(current_user.adopter_foster_account&.id, @pet.id) %>
                     <div class='d-flex align-items-center mt-3'>
                       <h4 class="me-2 mb-0">
-                        <%= "Application Status: #{@adoption_application.human_enum_name(:status) || t('.status.default')}" %>
+                        <%= "#{t('organizations.adoptable_pets.show.application_status')} #{@adoption_application.human_enum_name(:status) || t('.status.default')}" %>
                       </h4>
                       <% if %w[under_review adoption_pending].include?(@adoption_application.status) %>
                         <%= image_tag('pause.png', height: '21') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,6 +370,7 @@ en:
       index:
         header: "Up for adoption"
       show:
+        application_status: "Application status:"
         adoption_process: "Adoption Process"
         please_read_faq_html: "Please read the %{faq_link} before applying to adopt."
         create_an_account: "Create an account to apply for this pet"


### PR DESCRIPTION
# 🔗 Issue
N/A

# ✍️ Description
Playing in the dev environment I noted that we were getting a translation error after submitting an application on a pet. Calling send on the status enum value was returning an error because it is not a method. We need to pass the status symbol rather than value to this method for it to work. 

To reproduce, on main branch, log in as an adopter and apply to adopt a pet. You should see: 
![image](https://github.com/rubyforgood/pet-rescue/assets/95949082/c16bc7c7-9590-413b-8e3f-52a757679728)

