### PR TITLE
Issue 859 - Remove Copy link option from the ellipsis menu in the Pets table

### DIFF
--- a/app/views/organizations/staff/pets/_pet_table.html.erb
+++ b/app/views/organizations/staff/pets/_pet_table.html.erb
@@ -50,9 +50,6 @@
                     <%= link_to staff_pet_path(pet), class: 'dropdown-item' do %>
                       <i class="fe fe-edit dropdown-item-icon"></i>Edit Details
                     <% end %>
-                    <%= link_to staff_pet_path(pet), class: 'dropdown-item' do %>
-                      <i class="fe fe-link dropdown-item-icon"></i>Copy link
-                    <% end %>
                     <%= button_to [:staff, pet], method: :delete, class: 'dropdown-item', data: { turbo_confirm: t('general.are_you_sure_delete_pet') } do %>
                       <i class="fe fe-trash dropdown-item-icon"></i>Delete
                     <% end %>


### PR DESCRIPTION
# 🔗 Issue
[859](https://github.com/rubyforgood/pet-rescue/issues/859)

# ✍️ Description
This change removes the `Copy link` option in the ellipsis menu in the Pets table. 

# 📷 Screenshots/Demos
Before:
<img width="324" alt="Screenshot 2024-07-06 at 14 38 32" src="https://github.com/rubyforgood/pet-rescue/assets/1057497/aecddc89-e9e6-46e6-8556-5af4f7ba3039">

After:
<img width="278" alt="Screenshot 2024-07-05 at 22 41 21" src="https://github.com/rubyforgood/pet-rescue/assets/1057497/0ee0984b-be74-426c-9969-d14c04385bc7">

