### PR TITLE
User person

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,6 +22,7 @@ class Organization < ApplicationRecord
   has_many :default_pet_tasks
   has_many :forms, class_name: "CustomForm::Form", dependent: :destroy
   has_many :faqs
+  has_many :people
 
   has_one :profile, dependent: :destroy, class_name: "OrganizationProfile", required: true
   has_one :location, through: :profile

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -25,6 +25,8 @@ class Person < ApplicationRecord
   acts_as_tenant(:organization)
   has_one :form_submission, dependent: :destroy
 
+  has_one :user, dependent: :destroy
+
   validates :name, presence: true
   validates :email, presence: true,
     uniqueness: {case_sensitive: false, scope: :organization_id}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,9 @@ class User < ApplicationRecord
   has_one :staff_account, dependent: :destroy
   has_one :adopter_foster_account, dependent: :destroy
 
-  belongs_to :person
+  # Once we've migrated the existing data to connect a user to a person,
+  # we should remove the optional: true part
+  belongs_to :person, optional: true
 
   accepts_nested_attributes_for :adopter_foster_account
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@
 #  updated_at             :datetime         not null
 #  invited_by_id          :bigint
 #  organization_id        :bigint
+#  person_id              :bigint
 #
 # Indexes
 #
@@ -30,7 +31,12 @@
 #  index_users_on_invited_by            (invited_by_type,invited_by_id)
 #  index_users_on_invited_by_id         (invited_by_id)
 #  index_users_on_organization_id       (organization_id)
+#  index_users_on_person_id             (person_id)
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (person_id => people.id)
 #
 class User < ApplicationRecord
   include Avatarable

--- a/db/migrate/20240719034910_add_person_id_to_user.rb
+++ b/db/migrate/20240719034910_add_person_id_to_user.rb
@@ -1,0 +1,7 @@
+class AddPersonIdToUser < ActiveRecord::Migration[7.1]
+  def change
+    change_table :users do |t|
+      t.references :person, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_28_225125) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_19_034910) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -346,11 +346,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_225125) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.bigint "person_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
     t.index ["organization_id"], name: "index_users_on_organization_id"
+    t.index ["person_id"], name: "index_users_on_person_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -393,4 +395,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_28_225125) do
   add_foreign_key "submitted_answers", "questions"
   add_foreign_key "submitted_answers", "users"
   add_foreign_key "tasks", "pets"
+  add_foreign_key "users", "people"
 end

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -8,6 +8,7 @@ class OrganizationTest < ActiveSupport::TestCase
     should have_many(:users).through(:staff_accounts)
     should have_many(:pets)
     should have_many(:faqs)
+    should have_many(:people)
 
     should have_one(:profile).dependent(:destroy).required
     should have_one(:form_submission).dependent(:destroy)

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class PersonTest < ActiveSupport::TestCase
+  context "associations" do
+    should have_one(:user).dependent(:destroy)
+  end
+
   context "validations" do
     should validate_presence_of(:name)
     should validate_presence_of(:email)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,6 +9,7 @@ class UserTest < ActiveSupport::TestCase
   context "associations" do
     should have_one(:staff_account).dependent(:destroy)
     should have_one(:adopter_foster_account).dependent(:destroy)
+    should belong_to(:person).required(false)
   end
 
   context "validations" do
@@ -22,6 +23,36 @@ class UserTest < ActiveSupport::TestCase
 
       user2 = build(:user, email: user.email)
       assert user2.invalid?
+    end
+  end
+
+  context "creation" do
+    should "attach to an existing person" do
+      person = create(:person, email: "adopter@example.com")
+      user = create(:user, email: "adopter@example.com")
+
+      assert_equal person, user.person
+    end
+
+    should "not attach to people in other organizations" do
+      person = nil
+
+      ActsAsTenant.with_mutable_tenant do
+        other = create(:organization)
+        person = create(:person, email: "adopter@example.com", organization: other)
+      end
+
+      assert_equal("adopter@example.com", person.email)
+
+      user = create(:user, email: "adopter@example.com")
+      assert_not_equal person, user.person
+    end
+
+    should "create a person if none exists" do
+      user = create(:user, email: "tester@example.com", first_name: "Jane", last_name: "Smith")
+
+      assert_equal "Jane Smith", user.person.name
+      assert_equal "tester@example.com", user.person.email
     end
   end
 
@@ -39,7 +70,7 @@ class UserTest < ActiveSupport::TestCase
   context "#full_name" do
     context "format is :default" do
       should "return `First Last`" do
-        user = create(:user, first_name: "First", last_name: "Last")
+        user = build(:user, first_name: "First", last_name: "Last")
 
         assert_equal "First Last", user.full_name
       end
@@ -47,7 +78,7 @@ class UserTest < ActiveSupport::TestCase
 
     context "format is :default" do
       should "return `First Last`" do
-        user = create(:user, first_name: "First", last_name: "Last")
+        user = build(:user, first_name: "First", last_name: "Last")
 
         assert_equal "First Last", user.full_name(:default)
       end
@@ -55,7 +86,7 @@ class UserTest < ActiveSupport::TestCase
 
     context "format is :last_first" do
       should "return `Last, First`" do
-        user = create(:user, first_name: "First", last_name: "Last")
+        user = build(:user, first_name: "First", last_name: "Last")
 
         assert_equal "Last, First", user.full_name(:last_first)
       end
@@ -63,7 +94,7 @@ class UserTest < ActiveSupport::TestCase
 
     context "format is unsupported" do
       should "raise ArgumentError" do
-        user = create(:user, first_name: "First", last_name: "Last")
+        user = build(:user, first_name: "First", last_name: "Last")
 
         assert_raises(ArgumentError) { user.full_name(:foobar) }
       end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
#875 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

This adds a `person_id` column to the users table in the database, and wires up the various associations.

There's also a little bit of "rails magic" in the form of a `before` hook on user creation, which ensures that a person will be connected to any newly created users:  first, it will attempt to match an existing user with the same email address, and failing that, a new person will be created with a basic set of attributes.


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
