### PR TITLE
Refactor donate page

### DIFF
--- a/app/controllers/organizations/adopter_fosterer/donations_controller.rb
+++ b/app/controllers/organizations/adopter_fosterer/donations_controller.rb
@@ -1,0 +1,10 @@
+module Organizations
+  module AdopterFosterer
+    class DonationsController < Organizations::BaseController
+      skip_verify_authorized only: [:index]
+      layout "adopter_foster_dashboard", only: :index
+
+      def index; end
+    end
+  end
+end

--- a/app/controllers/organizations/adopter_fosterer/donations_controller.rb
+++ b/app/controllers/organizations/adopter_fosterer/donations_controller.rb
@@ -4,7 +4,8 @@ module Organizations
       skip_verify_authorized only: [:index]
       layout "adopter_foster_dashboard", only: :index
 
-      def index; end
+      def index
+      end
     end
   end
 end

--- a/app/views/layouts/adopter_foster_dashboard.html.erb
+++ b/app/views/layouts/adopter_foster_dashboard.html.erb
@@ -69,7 +69,7 @@
                       </li>
                       <!-- Nav item -->
                       <li class="nav-item">
-                        <%= active_link_to adopter_fosterer_dashboard_index_path, class: "nav-link" do %>
+                        <%= active_link_to adopter_fosterer_donations_path, class: "nav-link" do %>
                           <i class="fe fe-dollar-sign nav-icon"></i> Donate
                         <% end %>
                       </li>

--- a/app/views/organizations/adopter_fosterer/donations/index.html.erb
+++ b/app/views/organizations/adopter_fosterer/donations/index.html.erb
@@ -1,0 +1,8 @@
+<%= render DashboardPageComponent.new do |c| %>
+  <% c.with_header_title { t('static_pages.donate.donate') } %>
+  <% c.with_body do %>
+    <div class="justify-content-md-between mb-4 mb-xl-0 gx-3">
+      <%= render "static_pages/donate_content" %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/static_pages/_donate_content.html.erb
+++ b/app/views/static_pages/_donate_content.html.erb
@@ -1,0 +1,21 @@
+<div class="col-md-8 ps-md-4 bigger pb-5 pb-md-0">
+  <p>
+    <%= t('static_pages.donate.sentence_one', organization_name: Current.tenant.name) %>
+  </p>
+  <p>
+    <%= t('static_pages.donate.sentence_two') %>
+  </p>
+
+  <div class="row text-center mt-5">
+    <div class="col-8 border p-5 shadow-sm rounded bg-white">
+      <h3 class='mb-4'><%= t('static_pages.donate.donate_now_at') %></h3>
+      <div class="text-center mt-2">
+        <% if Current.tenant.profile.donation_url %>
+          <%= link_to Current.tenant.profile.donation_url, Current.tenant.profile.donation_url, target: '_blank'  %>
+        <% else %>
+          <p><%= sanitize(t('static_pages.donate.contact_us_to_donate', href: link_to(t('static_pages.donate.contact_us'), new_contact_path))) %></p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/_donate_content.html.erb
+++ b/app/views/static_pages/_donate_content.html.erb
@@ -10,7 +10,7 @@
     <div class="col-8 border p-5 shadow-sm rounded bg-white">
       <h3 class='mb-4'><%= t('static_pages.donate.donate_now_at') %></h3>
       <div class="text-center mt-2">
-        <% if Current.tenant.profile.donation_url %>
+        <% if Current.tenant.profile.donation_url.present? %>
           <%= link_to Current.tenant.profile.donation_url, Current.tenant.profile.donation_url, target: '_blank'  %>
         <% else %>
           <p><%= sanitize(t('static_pages.donate.contact_us_to_donate', href: link_to(t('static_pages.donate.contact_us'), new_contact_path))) %></p>

--- a/app/views/static_pages/donate.html.erb
+++ b/app/views/static_pages/donate.html.erb
@@ -1,11 +1,3 @@
-<%# set header to ensure full page reload to enable PayPal SDK to work properly %>
-<%# see: https://turbo.hotwired.dev/handbook/drive#ensuring-specific-pages-trigger-a-full-reload %>
-<% content_for :head do %>
-  <meta name="turbo-visit-control" content="reload">
-<% end %>
-
-<script src="https://www.paypalobjects.com/donate/sdk/donate-sdk.js" charset="UTF-8"></script>
-
 <section class="pt-5 pb-5" id="donate">
 	<div class="container mb-md-5 mt-md-5">
 
@@ -21,51 +13,8 @@
 			<div class="col-md-4 mb-4 mb-md-0">
 				<%= image_tag('about1.jpg', alt: 'Pet in Mexico', class: 'card-img-top rounded') %>
 			</div>
-			<div class="col-md-8 ps-md-4 bigger pb-5 pb-md-0">
-				<p>
-					Baja Pet Rescue relies heavily on donations to keep the program up and running. Even though things are generally cheaper in Mexico, the cost of rescuing each pet mounts up quickly.
-				</p>
-				<br/>
-				<p>
-					Please consider donating to Danielle today so she can continue giving these pets a chance at a healthier, happier life.
-				</p>	
-				<div class="row text-center mt-5">
-					<div class="col-8 offset-2 border p-5 shadow-sm 
-											rounded bg-white">
-						<h3 class='mb-4'>Donate now via Paypal</h3>
 
-						<div id="paypal-donate-button-container" class="text-center mt-2">
-							<script>
-								const business_id = '<%= ENV['PAYPAL_BUSINESS'] %>';
-								
-								PayPal.Donation.Button({
-									env: 'production',
-									business: business_id,
-									image: {
-										src: 'https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif',
-										title: 'Donate to Baja Pet Rescue via Paypal.',
-										alt: 'Donate with PayPal button'
-									},
-									onComplete: function (params) {
-										params["source"] = "Paypal"
-										const csrfToken = document.querySelector('[name="csrf-token"]').content
-
-										fetch('https://www.bajapetrescue.com/donations', {
-											method: 'POST',
-											headers: {
-												'Content-Type': 'application/json',
-												'Accept': 'application/json',
-												'X-CSRF-Token': csrfToken
-											},
-											body: JSON.stringify(params)
-										});
-									},
-								}).render('#paypal-donate-button-container');
-							</script>
-						</div>
-					</div>
-				</div>
-			</div>
+			<%= render "donate_content" %>
 		</div> <!--row-->
 	</div> <!--container-->
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -687,3 +687,11 @@ en:
   contacts:
     create:
       success: "Message sent!"
+  static_pages:
+    donate:
+      contact_us: "Contact us"
+      contact_us_to_donate: "%{href} to ask how you can donate"
+      donate: "Donate"
+      donate_now_at: "Donate now at:"
+      sentence_one: "%{organization_name} relies heavily on donations from people like you to help keep the program up and running."
+      sentence_two: "Please consider donating today so we can continue giving these pets a chance at a healthier, happier life."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,6 @@ Rails.application.routes.draw do
     invitations: "organizations/staff/invitations"
   }
 
-  resources :donations, only: [:create]
-
   scope module: :organizations do
     resources :home, only: [:index]
     resources :adoptable_pets, only: %i[index show]
@@ -59,6 +57,7 @@ Rails.application.routes.draw do
 
     namespace :adopter_fosterer do
       resource :profile, except: :destroy
+      resources :donations, only: [:index]
       resources :dashboard, only: [:index]
       resources :likes, only: [:index, :create, :destroy]
       resources :adopter_applications, path: "applications", only: %i[index create update]


### PR DESCRIPTION
…oster dashboard

# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/887

# ✍️ Description
PR refactors the donate page to use generic copy and render the org's donate link in the card. The view logic was moved to a partial that could be used in the adopter foster dashboard context as well, as I think it's nice to keep link clicks in the dashboard within the dashboard. Gets rid of no longer required donation routes and logic that was specifically for baja pet rescue's paypal page.

If there is a donation URL, that is displayed, otherwise the link to contact us is displayed.

These pages could do with some design love, but they are MVP ready for now. 

<img width="1353" alt="image" src="https://github.com/user-attachments/assets/edda210c-9e8c-479c-a90c-b42ddbd7b890">

<img width="1366" alt="image" src="https://github.com/user-attachments/assets/d5fa5449-56d8-4a15-a4c5-8829fa6f8f99">

with URL
<img width="1390" alt="image" src="https://github.com/user-attachments/assets/55d5ea55-5965-4429-9fcb-984399d3cad6">


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
