### PR TITLE
Configure docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   app:
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -b '0.0.0.0'"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle install && bundle exec rails s -b '0.0.0.0'"
     volumes:
       - .:/petrescue
     ports:
@@ -30,12 +30,14 @@ services:
 
   sass:
     build: .
-    command: bundle exec rails dartsass:watch
+    command: bash -c "bundle install && bundle exec rails dartsass:watch"
     volumes:
       - .:/petrescue
     depends_on:
       app:
         condition: service_started
+    stdin_open: true
+    tty: true
 
 volumes:
   postgres-data:


### PR DESCRIPTION
This runs bundle install when starting up the containers. It means a slightly slower start up, but I am otherwise having to enter the bundle install command manually in the docker-compose file which is more of a pain. I also configured SASS service to remain open and interactive, otherwise it boots up, then exits.

# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
