### PR TITLE
Add PetAvatarComponent to staff pets index page for consistent design

### DIFF
--- a/app/views/organizations/staff/pets/_pet_table.html.erb
+++ b/app/views/organizations/staff/pets/_pet_table.html.erb
@@ -16,13 +16,7 @@
           <tr>
             <td>
               <div class="d-flex align-items-center">
-                <div class="icon-shape icon-lg rounded-3 border">
-                  <% if pet.images.attached? %>
-                    <%= image_tag pet.images.first, class: 'card-img' %>
-                  <% else %>
-                    <%= image_tag('coming_soon.jpg', class: 'card-img') %>
-                  <% end %>
-                </div>
+                <%= render PetAvatarComponent.new(pet)%>
                 <div class="ms-3">
                   <h4 class="mb-0">
                     <%= link_to pet.name, staff_pet_path(pet), class: 'text-inherit' %>


### PR DESCRIPTION
# 🔗 Issue
#932 

# ✍️ Description
- [x] Added the PetAvatarComponent to the staff pets index page to ensure a uniform and consistent design across the UI.


# 📷 Screenshots/Demos
[Screencast from 2024-08-29 10-19-30.webm](https://github.com/user-attachments/assets/15d304f0-5cd3-4c3e-8699-774b5cd7ef41)
