### PR TITLE
Replaced items with limit in the pagy method

### DIFF
--- a/app/controllers/organizations/adoptable_pets_controller.rb
+++ b/app/controllers/organizations/adoptable_pets_controller.rb
@@ -11,7 +11,7 @@ class Organizations::AdoptablePetsController < Organizations::BaseController
       with: Organizations::AdoptablePetPolicy).ransack(params[:q])
     @pagy, paginated_adoptable_pets = pagy(
       @q.result,
-      items: 9
+      limit: 9
     )
     @pets = paginated_adoptable_pets
   end

--- a/app/controllers/organizations/staff/adoption_application_reviews_controller.rb
+++ b/app/controllers/organizations/staff/adoption_application_reviews_controller.rb
@@ -20,7 +20,7 @@ class Organizations::Staff::AdoptionApplicationReviewsController < Organizations
       @pets_with_applications = filter_by_application_status(@pets_with_applications, status_filter)
     end
 
-    @pagy, @pets_with_applications = pagy(@pets_with_applications, items: 10)
+    @pagy, @pets_with_applications = pagy(@pets_with_applications, limit: 10)
   end
 
   def edit

--- a/app/controllers/organizations/staff/default_pet_tasks_controller.rb
+++ b/app/controllers/organizations/staff/default_pet_tasks_controller.rb
@@ -12,7 +12,7 @@ class Organizations::Staff::DefaultPetTasksController < Organizations::BaseContr
     @q = DefaultPetTask.ransackable_tasks(tasks, params)
     @default_pet_tasks = @q.result
 
-    @pagy, @default_pet_tasks = pagy(@default_pet_tasks, items: 10)
+    @pagy, @default_pet_tasks = pagy(@default_pet_tasks, limit: 10)
   end
 
   def new

--- a/app/controllers/organizations/staff/manage_fosters_controller.rb
+++ b/app/controllers/organizations/staff/manage_fosters_controller.rb
@@ -32,7 +32,7 @@ class Organizations::Staff::ManageFostersController < Organizations::BaseControl
       @q.result
         .includes(:pet, :user)
         .order("pets.updated_at DESC"),
-      items: 10
+      limit: 10
     )
     @foster_pets = paginated_fosters.group_by(&:pet)
   end

--- a/app/controllers/organizations/staff/pets_controller.rb
+++ b/app/controllers/organizations/staff/pets_controller.rb
@@ -8,7 +8,7 @@ class Organizations::Staff::PetsController < Organizations::BaseController
     authorize! Pet, context: {organization: Current.organization}
 
     @q = Pet.ransack(params[:q])
-    @pagy, @pets = pagy(authorized_scope(@q.result), items: 10)
+    @pagy, @pets = pagy(authorized_scope(@q.result), limit: 10)
   end
 
   def new


### PR DESCRIPTION
# 🔗 Issue
#944 

# ✍️ Description
Replaced `items` with `limit` to improve record handling and ensure accurate implementation of record limits.
