### PR TITLE
Fix Pet filter bug in staff view

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -132,7 +132,7 @@ class Pet < ApplicationRecord
   end
 
   def self.ransack_adopted(boolean)
-    boolean ? adopted : unadopted
+    boolean ? adopted : Pet.where.not(id: Pet.adopted)
   end
 
   def self.ransack_birth_date(date)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -76,6 +76,7 @@ class Pet < ApplicationRecord
   ]
 
   scope :adopted, -> { joins(:matches).merge(Match.adoptions) }
+  scope :unadopted, -> { where.not(id: Pet.adopted) }
   scope :unmatched, -> { includes(:matches).where(matches: {id: nil}) }
   scope :published, -> { where(published: true) }
   scope :fostered, -> { joins(:matches).merge(Match.fosters) }
@@ -131,13 +132,9 @@ class Pet < ApplicationRecord
     [:ransack_adopted, :ransack_birth_date]
   end
 
-  # Using string values to get around a known ransack bug: https://github.com/activerecord-hackery/ransack/issues/1375
+  # Using string values to get around ransack bug: https://github.com/activerecord-hackery/ransack/issues/1375
   def self.ransack_adopted(adoption_state)
-    if adoption_state == "adopted"
-      adopted
-    else
-      Pet.where.not(id: Pet.adopted)
-    end
+    adoption_state == "adopted" ? adopted : unadopted
   end
 
   def self.ransack_birth_date(date)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -134,7 +134,7 @@ class Pet < ApplicationRecord
 
   # Using string values to get around ransack bug: https://github.com/activerecord-hackery/ransack/issues/1375
   def self.ransack_adopted(adoption_state)
-    adoption_state == "adopted" ? adopted : unadopted
+    (adoption_state == "adopted") ? adopted : unadopted
   end
 
   def self.ransack_birth_date(date)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -131,8 +131,13 @@ class Pet < ApplicationRecord
     [:ransack_adopted, :ransack_birth_date]
   end
 
-  def self.ransack_adopted(boolean)
-    boolean ? adopted : Pet.where.not(id: Pet.adopted)
+  # Using string values to get around a known ransack bug: https://github.com/activerecord-hackery/ransack/issues/1375
+  def self.ransack_adopted(adoption_state)
+    if adoption_state == "adopted"
+      adopted
+    else
+      Pet.where.not(id: Pet.adopted)
+    end
   end
 
   def self.ransack_birth_date(date)

--- a/app/views/organizations/staff/pets/index.html.erb
+++ b/app/views/organizations/staff/pets/index.html.erb
@@ -24,7 +24,7 @@
               </div>
               <div class="form-group">
                 <%= f.label :ransack_adopted, "Status" %>
-                <%= f.select :ransack_adopted, [['Adopted', true], ['Unadopted', false]], {include_blank: 'All'}, class: "form-select" %>
+                <%= f.select :ransack_adopted, [['Adopted', 'adopted'], ['Unadopted', 'unadopted']], {include_blank: 'All'}, class: "form-select" %>
               </div>
             </div>
             <div class='d-flex flex-column w-100 w-md-auto flex-md-row gap-2'>

--- a/test/controllers/organizations/staff/pets_controller_test.rb
+++ b/test/controllers/organizations/staff/pets_controller_test.rb
@@ -32,9 +32,9 @@ class Organizations::PetsControllerTest < ActionDispatch::IntegrationTest
         end
       end
 
-      should "filter by adopted status" do 
-        pet_2 = create(:pet, :adopted, name: "Cutie")
-        pet_3 = create(:pet, :adoption_pending, name: "Pie")
+      should "filter by adopted status" do
+        create(:pet, :adopted, name: "Cutie")
+        create(:pet, :adoption_pending, name: "Pie")
 
         get staff_pets_url, params: {q: {ransack_adopted: "adopted"}}
         assert_response :success
@@ -43,8 +43,8 @@ class Organizations::PetsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "filter by unadopted status" do
-        pet_2 = create(:pet, :adopted, name: "Cutie")
-        pet_3 = create(:pet, :adoption_pending, name: "Pie")
+        create(:pet, :adopted, name: "Cutie")
+        create(:pet, :adoption_pending, name: "Pie")
 
         get staff_pets_url, params: {q: {ransack_adopted: "unadopted"}}
         assert_response :success
@@ -53,28 +53,28 @@ class Organizations::PetsControllerTest < ActionDispatch::IntegrationTest
         assert_not_includes assigns[:pets].map { |pet| pet.name }, "Cutie"
       end
 
-      should "filter by sex" do 
-        pet_2 = create(:pet, sex: "Female")
-        pet_3 = create(:pet, sex: "Male")
-        pet_4 = create(:pet, sex: "Female")
+      should "filter by sex" do
+        create(:pet, sex: "Female")
+        create(:pet, sex: "Male")
+        create(:pet, sex: "Female")
 
         get staff_pets_url, params: {q: {sex_eq: "Male"}}
         assert_response :success
 
         assert_equal 1, assigns[:pets].count
-        assert_equal 1, assigns[:pets].select { |pet| pet.sex == "Male" }.count
+        assert_equal 1, assigns[:pets].count { |pet| pet.sex == "Male" }
       end
 
-      should "filter by species" do 
-        pet_2 = create(:pet, species: "Cat")
-        pet_3 = create(:pet, species: "Dog")
-        pet_4 = create(:pet, species: "Cat")
+      should "filter by species" do
+        create(:pet, species: "Cat")
+        create(:pet, species: "Dog")
+        create(:pet, species: "Cat")
 
         get staff_pets_url, params: {q: {species_eq: "2"}}
         assert_response :success
 
         assert_equal 2, assigns[:pets].count
-        assert_equal 2, assigns[:pets].select { |pet| pet.species == "Cat" }.count
+        assert_equal 2, assigns[:pets].count { |pet| pet.species == "Cat" }
       end
     end
 

--- a/test/controllers/organizations/staff/pets_controller_test.rb
+++ b/test/controllers/organizations/staff/pets_controller_test.rb
@@ -40,7 +40,6 @@ class Organizations::PetsControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
 
         assert_equal 2, assigns[:pets].count
-        assert_equal "Cutie", assigns[:pets].first.name
         assert_not_includes "Cutie", assigns[:pets].map { |pet| pet.name }
       end
 

--- a/test/controllers/organizations/staff/pets_controller_test.rb
+++ b/test/controllers/organizations/staff/pets_controller_test.rb
@@ -7,7 +7,7 @@ class Organizations::PetsControllerTest < ActionDispatch::IntegrationTest
 
     setup do
       @organization = ActsAsTenant.current_tenant
-      @pet = create(:pet, sex: "Female", species: "Dog")
+      @pet = create(:pet, :adoption_pending, sex: "Female", species: "Dog")
 
       user = create(:admin)
       sign_in user
@@ -32,15 +32,25 @@ class Organizations::PetsControllerTest < ActionDispatch::IntegrationTest
         end
       end
 
-      should "filter by status" do 
+      should "filter by adopted status" do 
         pet_2 = create(:pet, :adopted, name: "Cutie")
         pet_3 = create(:pet, :adoption_pending, name: "Pie")
 
-        get staff_pets_url, params: {q: {ransack_adopted: "false"}}
+        get staff_pets_url, params: {q: {ransack_adopted: "adopted"}}
+        assert_response :success
+
+        assert_equal 1, assigns[:pets].count
+      end
+
+      should "filter by unadopted status" do
+        pet_2 = create(:pet, :adopted, name: "Cutie")
+        pet_3 = create(:pet, :adoption_pending, name: "Pie")
+
+        get staff_pets_url, params: {q: {ransack_adopted: "unadopted"}}
         assert_response :success
 
         assert_equal 2, assigns[:pets].count
-        assert_not_includes "Cutie", assigns[:pets].map { |pet| pet.name }
+        assert_not_includes assigns[:pets].map { |pet| pet.name }, "Cutie"
       end
 
       should "filter by sex" do 

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -127,21 +127,36 @@ class PetTest < ActiveSupport::TestCase
     end
   end
 
-  context "#ransack_adopted" do
+  context "ransack_adopted" do
     setup do
       create(:pet)
       create(:pet)
       create(:pet, :adopted)
     end
 
-    should "return adopted pets" do
+    should "should return adopted pets" do
       adopted_pets = Pet.ransack_adopted(true)
       assert_equal 1, adopted_pets.count
     end
 
-    should "return unadopted pets" do
+    should "should return unadopted pets" do
       unadopted_pets = Pet.ransack_adopted(false)
       assert_equal 2, unadopted_pets.count
+    end
+
+    # FOR DEBUGGING
+    should "should return adopted pets via Pet.ransack" do
+      adopted_pets = Pet.ransack({"ransack_adopted"=>"true"})
+
+      assert_equal Pet.ransack_adopted(true).to_sql, Pet.ransack({"ransack_adopted"=>"true"}).result.to_sql
+      assert_equal 1, adopted_pets.result.count
+    end
+
+    should "should return unadopted pets via Pet.ransack" do
+      unadopted_pets = Pet.ransack({"ransack_adopted"=>false})
+
+      assert_equal Pet.ransack_adopted(false).to_sql, Pet.ransack({"ransack_adopted"=>"false"}).result.to_sql
+      assert_equal 2, unadopted_pets.result.count
     end
   end
 end

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -135,41 +135,25 @@ class PetTest < ActiveSupport::TestCase
     end
 
     should "should return adopted pets" do
-      adopted_pets = Pet.ransack_adopted(true)
+      adopted_pets = Pet.ransack_adopted("adopted")
       assert_equal 1, adopted_pets.count
     end
 
     should "should return unadopted pets" do
-      unadopted_pets = Pet.ransack_adopted(false)
+      unadopted_pets = Pet.ransack_adopted("unadopted")
       assert_equal 2, unadopted_pets.count
     end
 
-    # Passes.
     should "should return adopted pets via Pet.ransack" do
-      adopted_pets = Pet.ransack({"ransack_adopted"=>"true"})
+      adopted_pets = Pet.ransack({"ransack_adopted"=>"adopted"})
       assert_equal 1, adopted_pets.result.count
     end
 
-    # Fails
     should "should return unadopted pets via Pet.ransack" do
-      unadopted_pets = Pet.ransack({"ransack_adopted"=>"false"})
+      unadopted_pets = Pet.ransack({"ransack_adopted"=>"unadopted"})
 
       assert_equal Pet.ransack_adopted(false).to_sql, unadopted_pets.result.to_sql
       assert_equal 2, unadopted_pets.result.count
-    end
-
-    # For debugging purposes
-    # Passes
-    should "should return equivalent SQL for adopted" do
-      adopted_pets = Pet.ransack({"ransack_adopted"=>"true"})
-      assert_equal Pet.ransack_adopted(true).to_sql, adopted_pets.result.to_sql
-    end
-
-    # For debugging purposes
-    # Fails
-    should "should return equivalent SQL for unadopted" do
-      adopted_pets = Pet.ransack({"ransack_adopted"=>"false"})
-      assert_equal Pet.ransack_adopted(false).to_sql, adopted_pets.result.to_sql
     end
   end
 end

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -145,12 +145,12 @@ class PetTest < ActiveSupport::TestCase
     end
 
     should "should return adopted pets via Pet.ransack" do
-      adopted_pets = Pet.ransack({"ransack_adopted"=>"adopted"})
+      adopted_pets = Pet.ransack({"ransack_adopted" => "adopted"})
       assert_equal 1, adopted_pets.result.count
     end
 
     should "should return unadopted pets via Pet.ransack" do
-      unadopted_pets = Pet.ransack({"ransack_adopted"=>"unadopted"})
+      unadopted_pets = Pet.ransack({"ransack_adopted" => "unadopted"})
 
       assert_equal Pet.ransack_adopted(false).to_sql, unadopted_pets.result.to_sql
       assert_equal 2, unadopted_pets.result.count

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -148,14 +148,15 @@ class PetTest < ActiveSupport::TestCase
     should "should return adopted pets via Pet.ransack" do
       adopted_pets = Pet.ransack({"ransack_adopted"=>"true"})
 
-      assert_equal Pet.ransack_adopted(true).to_sql, Pet.ransack({"ransack_adopted"=>"true"}).result.to_sql
+      assert_equal Pet.ransack_adopted(true).to_sql, adopted_pets.result.to_sql
       assert_equal 1, adopted_pets.result.count
     end
 
+    # Fails. SQL isn't what we'd expect?
     should "should return unadopted pets via Pet.ransack" do
-      unadopted_pets = Pet.ransack({"ransack_adopted"=>false})
+      unadopted_pets = Pet.ransack({"ransack_adopted"=>"false"})
 
-      assert_equal Pet.ransack_adopted(false).to_sql, Pet.ransack({"ransack_adopted"=>"false"}).result.to_sql
+      assert_equal Pet.ransack_adopted(false).to_sql, unadopted_pets.result.to_sql
       assert_equal 2, unadopted_pets.result.count
     end
   end

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -144,20 +144,32 @@ class PetTest < ActiveSupport::TestCase
       assert_equal 2, unadopted_pets.count
     end
 
-    # FOR DEBUGGING
+    # Passes.
     should "should return adopted pets via Pet.ransack" do
       adopted_pets = Pet.ransack({"ransack_adopted"=>"true"})
-
-      assert_equal Pet.ransack_adopted(true).to_sql, adopted_pets.result.to_sql
       assert_equal 1, adopted_pets.result.count
     end
 
-    # Fails. SQL isn't what we'd expect?
+    # Fails
     should "should return unadopted pets via Pet.ransack" do
       unadopted_pets = Pet.ransack({"ransack_adopted"=>"false"})
 
       assert_equal Pet.ransack_adopted(false).to_sql, unadopted_pets.result.to_sql
       assert_equal 2, unadopted_pets.result.count
+    end
+
+    # For debugging purposes
+    # Passes
+    should "should return equivalent SQL for adopted" do
+      adopted_pets = Pet.ransack({"ransack_adopted"=>"true"})
+      assert_equal Pet.ransack_adopted(true).to_sql, adopted_pets.result.to_sql
+    end
+
+    # For debugging purposes
+    # Fails
+    should "should return equivalent SQL for unadopted" do
+      adopted_pets = Pet.ransack({"ransack_adopted"=>"false"})
+      assert_equal Pet.ransack_adopted(false).to_sql, adopted_pets.result.to_sql
     end
   end
 end

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -126,4 +126,22 @@ class PetTest < ActiveSupport::TestCase
       assert_not pet.is_adopted?
     end
   end
+
+  context "#ransack_adopted" do
+    setup do
+      create(:pet)
+      create(:pet)
+      create(:pet, :adopted)
+    end
+
+    should "return adopted pets" do
+      adopted_pets = Pet.ransack_adopted(true)
+      assert_equal 1, adopted_pets.count
+    end
+
+    should "return unadopted pets" do
+      unadopted_pets = Pet.ransack_adopted(false)
+      assert_equal 2, unadopted_pets.count
+    end
+  end
 end


### PR DESCRIPTION
# 🔗 Issue

https://github.com/rubyforgood/pet-rescue/issues/969

# ✍️ Description

This PR addresses a bug in the search filter resulting in the `unadopted` filter to not work as expected.

Changes made:
* Defines a missing `unadopted` scope.
* Update the `ransack_adopted` method to use strings instead of booleans to get around a known bug. Kudos to @coalest for pointing me to https://github.com/activerecord-hackery/ransack/issues/1375#issuecomment-1674885632.
* Add test coverage for `ransack_adopted` to ensure the adopted/unadopted filters work.
* Add missing test coverage for other filters in the search.