### PR TITLE
Donate partial style update

### DIFF
--- a/app/views/static_pages/_donate_content.html.erb
+++ b/app/views/static_pages/_donate_content.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
-    <div class="row d-flex align-items-center">
-      <div class=" col-xxl-5  col-xl-6 col-lg-6 col-12">
+    <div class="row d-flex">
+      <div class=" col-xxl-5 col-xl-6 col-lg-6 col-12">
         <div>
-          <h1 class="display-2 fw-bold mb-3"><span class="text-primary"><%= t('static_pages.donate.give') %></span> <%= t('static_pages.donate.give_sentence') %></h1>
-          <p class="lead mb-4"><%= t('static_pages.donate.sentence_one', organization_name: Current.tenant.name) %> <%= t('static_pages.donate.sentence_two') %></p>
+          <h1 class="fw-bold"><span class="text-primary"><%= t('static_pages.donate.give') %></span> <%= t('static_pages.donate.give_sentence') %></h1>
+          <p class="fs-4 mb-4"><%= t('static_pages.donate.sentence_one', organization_name: Current.tenant.name) %> <%= t('static_pages.donate.sentence_two') %></p>
           <% if Current.organization.donation_url.present? %>
             <%= link_to t('static_pages.donate.donate'), Current.organization.donation_url, target: '_blank', class: 'btn btn-primary btn-lg px-5'  %>
           <% else %>


### PR DESCRIPTION

# 🔗 Issue
N/A
# ✍️ Description
Updates styling on donate partial to fit both the `/donate` and `adopter_fosterer/donations` views

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/122b8c64-7232-4084-863b-94bc0f77ac65">

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/febc159d-1c4f-441e-9194-beb0530b58e1">

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
