### PR TITLE
Fix adopter application review status change bug

### DIFF
--- a/app/views/organizations/staff/adoption_application_reviews/update.turbo_stream.erb
+++ b/app/views/organizations/staff/adoption_application_reviews/update.turbo_stream.erb
@@ -1,5 +1,5 @@
-<%= turbo_stream.replace "table_adopter_application_#{@application.id}",
-        partial: "organizations/staff/pets/tabs/partials/application_info_table",
+<%= turbo_stream.replace "table_row_adopter_application_#{@application.id}",
+        partial: "organizations/staff/pets/tabs/partials/application_info_table_row",
         locals: {app: @application}%>
 <%= turbo_stream.replace "card_adopter_application_#{@application.id}",
         partial: "organizations/staff/pets/tabs/partials/application_info_card",

--- a/app/views/organizations/staff/pets/tabs/_applications.html.erb
+++ b/app/views/organizations/staff/pets/tabs/_applications.html.erb
@@ -23,11 +23,10 @@
         </thead>
         <tbody>
           <% applications.each do |app|%>
-            <%= render 'organizations/staff/pets/tabs/partials/application_info_table', app: app %>
+            <%= render 'organizations/staff/pets/tabs/partials/application_info_table_row', app: app %>
           <% end %>
         </tbody>
     </table>
-    <%# headers %>
   </div>
 </div>
 

--- a/app/views/organizations/staff/pets/tabs/partials/_application_info_card.html.erb
+++ b/app/views/organizations/staff/pets/tabs/partials/_application_info_card.html.erb
@@ -1,7 +1,6 @@
 <div class="pt-2 border-bottom border-3" id="<%= dom_id(app, :card) %>">
   <ul class="list-group list-group-flush">
 
-    <!-- applicant -->
     <li class="list-group-item">
       <span><%= t("organizations.staff.pets.applications.applicant")%>:</span>
       <div>
@@ -9,17 +8,14 @@
       </div>
     </li>
 
-    <!-- status -->
     <li class="list-group-item">
       <%= render 'organizations/staff/pets/tabs/partials/application_status', app: app %>
     </li>
 
-    <!-- create -->
     <li class="list-group-item">
       <%= render 'organizations/staff/pets/tabs/partials/application_create_button', app: app %>
     </li>
 
-    <!-- notes -->
     <li class="list-group-item">
       <%= render 'organizations/staff/pets/tabs/partials/application_notes', app: app, modal_id: 'card' %>
     </li>

--- a/app/views/organizations/staff/pets/tabs/partials/_application_info_table_row.html.erb
+++ b/app/views/organizations/staff/pets/tabs/partials/_application_info_table_row.html.erb
@@ -1,24 +1,23 @@
-<div id="<%= dom_id(app, :table) %>">
-  <!-- applicant -->
+<tr id="<%= dom_id(app, :table_row) %>">
   <td class="w-20 align-middle">
     <%= link_to "PLACEHOLDER FOR FORM ANSWERS", nil,
                                 class: "link-underline link-underline-opacity-0"  %>
   </td>
-  <!-- status -->
+
   <td class="w-20 align-middle" style="min-width: 220px;">
     <%= render 'organizations/staff/pets/tabs/partials/application_status', app: app %>
   </td>
-  <!-- create -->
+
   <% unless app.status == 'adoption_made' %>
-  <td class="w-20 align-middle">
-    <%= render 'organizations/staff/pets/tabs/partials/application_create_button', app: app %>
-  </td>
+    <td class="w-20 align-middle">
+      <%= render 'organizations/staff/pets/tabs/partials/application_create_button', app: app %>
+    </td>
   <% else %>
-  <td class="w-20 align-middle">
-  </td>
+    <td class="w-20 align-middle">
+    </td>
   <% end %>
-  <!-- notes -->
+
   <td class="w-20 align-middle">
     <%= render 'organizations/staff/pets/tabs/partials/application_notes', app: app, modal_id: 'table' %>
   </td>
-</div>
+</tr>

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -80,7 +80,7 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
   end
 
   def verify_application_elements(application)
-    assert_select "div[id='table_adopter_application_#{application.id}']" do
+    assert_select "div[id='table_row_adopter_application_#{application.id}']" do
       # adopter = application.adopter_foster_account.user
       # assert_select "a", text: "#{adopter.first_name} #{adopter.last_name}" re-instate this assertion once the Person and FormSubmission models are in place.
       assert_select "button", text: application.status.titleize

--- a/test/integration/adoption_application_reviews_test.rb
+++ b/test/integration/adoption_application_reviews_test.rb
@@ -80,9 +80,7 @@ class AdoptionApplicationReviewsTest < ActionDispatch::IntegrationTest
   end
 
   def verify_application_elements(application)
-    assert_select "div[id='table_row_adopter_application_#{application.id}']" do
-      # adopter = application.adopter_foster_account.user
-      # assert_select "a", text: "#{adopter.first_name} #{adopter.last_name}" re-instate this assertion once the Person and FormSubmission models are in place.
+    assert_select "tr[id='table_row_adopter_application_#{application.id}']" do
       assert_select "button", text: application.status.titleize
     end
   end


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/pet-rescue/issues/1035

# ✍️ Description
Cannot use a div as a child inside a table. So, the div with the ID to replace sits outside the table and the turbostream updates it...and does not replace the old row...see gif.

bug
![bug](https://github.com/user-attachments/assets/09542ee7-5f30-4642-aa5f-fbf2e1dacdad)

Fix
![fix](https://github.com/user-attachments/assets/1f521f73-02f7-4e15-96f8-a2dd37ac0330)

