### PR TITLE
Add NOT NULL constraint to application_paused field on pets

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -3,7 +3,7 @@
 # Table name: pets
 #
 #  id                 :bigint           not null, primary key
-#  application_paused :boolean          default(FALSE)
+#  application_paused :boolean          default(FALSE), not null
 #  birth_date         :datetime         not null
 #  breed              :string
 #  description        :text

--- a/db/migrate/20241008095758_add_application_paused_not_null_constraint_to_pets.rb
+++ b/db/migrate/20241008095758_add_application_paused_not_null_constraint_to_pets.rb
@@ -1,0 +1,8 @@
+class AddApplicationPausedNotNullConstraintToPets < ActiveRecord::Migration[7.2]
+  def change
+    # Add NOT NULL constraint to application_paused column and update any current NULL values to false
+    safety_assured do
+      change_column_null :pets, :application_paused, false, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_04_082759) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_08_095758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_04_082759) do
     t.text "description"
     t.string "sex"
     t.string "name"
-    t.boolean "application_paused", default: false
+    t.boolean "application_paused", default: false, null: false
     t.datetime "birth_date", null: false
     t.integer "weight_from", null: false
     t.integer "weight_to", null: false


### PR DESCRIPTION
# 🔗 Issue
There is no direct issue for this PR, but it is related to #795. 

# ✍️ Description
In the issue mentioned above, we want to add a filter to pets for their paused status, which is a boolean value with a default set to false. A minor issue is that there is no `NOT NULL` constraint on that column so technically a pet could have `NULL` for their paused status and therefore would be missing when filtering by true or false.

This PR assumes that a `NULL` value for `application_paused` doesn't make sense for a pet. 
