### PR TITLE
795 Add additional filters on staff pet view

### DIFF
--- a/app/models/concerns/pet_ransackable.rb
+++ b/app/models/concerns/pet_ransackable.rb
@@ -1,0 +1,34 @@
+module PetRansackable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def ransackable_attributes(auth_object = nil)
+      %w[name sex species breed placement_type application_paused published]
+    end
+
+    def ransackable_associations(auth_object = nil)
+      ["adopter_applications"]
+    end
+
+    def ransackable_scopes(auth_object = nil)
+      [:ransack_adopted, :ransack_birth_date]
+    end
+
+    # Using string values to get around ransack bug: https://github.com/activerecord-hackery/ransack/issues/1375
+    def ransack_adopted(adoption_state)
+      (adoption_state == "adopted") ? adopted : unadopted
+    end
+
+    def ransack_birth_date(date)
+      start_date, end_date = date.split("/")
+
+      if start_date != "none" && end_date != "none"
+        where("birth_date >= ? AND birth_date <= ?", start_date, end_date)
+      elsif start_date == "none" && end_date != "none"
+        where("birth_date <= ?", end_date)
+      elsif start_date != "none" && end_date == "none"
+        where("birth_date >= ?", start_date)
+      end
+    end
+  end
+end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -64,8 +64,8 @@ class Pet < ApplicationRecord
 
   validate :sensible_placement_type
 
-  enum species: {"Dog" => 1, "Cat" => 2}
-  enum placement_type: ["Adoptable", "Fosterable", "Adoptable and Fosterable"]
+  enum :species, {"Dog" => 1, "Cat" => 2}
+  enum :placement_type, ["Adoptable", "Fosterable", "Adoptable and Fosterable"]
 
   WEIGHT_UNIT_LB = "lb".freeze
   WEIGHT_UNIT_KG = "kg".freeze
@@ -119,7 +119,7 @@ class Pet < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["name", "sex", "species", "breed"]
+    %w[name sex species breed placement_type application_paused published]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -28,6 +28,7 @@
 #  fk_rails_...  (organization_id => organizations.id)
 #
 class Pet < ApplicationRecord
+  include PetRansackable
   include PetTaskable
 
   acts_as_tenant(:organization)
@@ -115,35 +116,6 @@ class Pet < ApplicationRecord
   def sensible_placement_type
     if matches.where(end_date: DateTime.now..).exists? && placement_type == "Adoptable"
       errors.add(:placement_type, I18n.t("activerecord.errors.models.pet.attributes.placement_type.sensible"))
-    end
-  end
-
-  def self.ransackable_attributes(auth_object = nil)
-    %w[name sex species breed placement_type application_paused published]
-  end
-
-  def self.ransackable_associations(auth_object = nil)
-    ["adopter_applications"]
-  end
-
-  def self.ransackable_scopes(auth_object = nil)
-    [:ransack_adopted, :ransack_birth_date]
-  end
-
-  # Using string values to get around ransack bug: https://github.com/activerecord-hackery/ransack/issues/1375
-  def self.ransack_adopted(adoption_state)
-    (adoption_state == "adopted") ? adopted : unadopted
-  end
-
-  def self.ransack_birth_date(date)
-    start_date, end_date = date.split("/")
-
-    if start_date != "none" && end_date != "none"
-      where("birth_date >= ? AND birth_date <= ?", start_date, end_date)
-    elsif start_date == "none" && end_date != "none"
-      where("birth_date <= ?", end_date)
-    elsif start_date != "none" && end_date == "none"
-      where("birth_date >= ?", start_date)
     end
   end
 end

--- a/app/views/organizations/staff/pets/index.html.erb
+++ b/app/views/organizations/staff/pets/index.html.erb
@@ -23,8 +23,20 @@
                 <%= f.select :species_eq, Pet.species, {include_blank: 'All'}, class: "form-select" %>
               </div>
               <div class="form-group">
-                <%= f.label :ransack_adopted, "Status" %>
-                <%= f.select :ransack_adopted, [['Adopted', 'adopted'], ['Unadopted', 'unadopted']], {include_blank: 'All'}, class: "form-select" %>
+                <%= f.label :ransack_adopted, "Adoption Status" %>
+                <%= f.select :ransack_adopted, [['Adopted', 'adopted'], ['Not adopted', 'unadopted']], {include_blank: 'All'}, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :placement_type_eq, "Placement type" %>
+                <%= f.select :placement_type_eq, Pet.placement_types, {include_blank: 'All'}, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :application_paused_eq, "Paused" %>
+                <%= f.select :application_paused_eq, [['Yes', true], ['No', false]], {include_blank: 'All'}, class: "form-select" %>
+              </div>
+              <div class="form-group">
+                <%= f.label :published_eq, "Published" %>
+                <%= f.select :published_eq, [['Yes', true], ['No', false]], {include_blank: 'All'}, class: "form-select" %>
               </div>
             </div>
             <div class='d-flex flex-column w-100 w-md-auto flex-md-row gap-2'>

--- a/test/controllers/organizations/staff/pets_controller_test.rb
+++ b/test/controllers/organizations/staff/pets_controller_test.rb
@@ -76,6 +76,42 @@ class Organizations::PetsControllerTest < ActionDispatch::IntegrationTest
         assert_equal 2, assigns[:pets].count
         assert_equal 2, assigns[:pets].count { |pet| pet.species == "Cat" }
       end
+
+      should "filter by placement_type" do
+        create(:pet, placement_type: "Adoptable")
+        create(:pet, placement_type: "Fosterable")
+        create(:pet, placement_type: "Adoptable and Fosterable")
+
+        get staff_pets_url, params: {q: {placement_type_eq: "0"}}
+        assert_response :success
+
+        assert_equal 1, assigns[:pets].count
+        assert_equal 1, assigns[:pets].count { |pet| pet.placement_type == "Adoptable" }
+      end
+
+      should "filter by application_paused" do
+        create(:pet, application_paused: false)
+        create(:pet, application_paused: true)
+        create(:pet, application_paused: true)
+
+        get staff_pets_url, params: {q: {application_paused_eq: "true"}}
+        assert_response :success
+
+        assert_equal 2, assigns[:pets].count
+        assert_equal 2, assigns[:pets].count { |pet| !!pet.application_paused }
+      end
+
+      should "filter by published" do
+        create(:pet, published: true)
+        create(:pet, published: false)
+        create(:pet, published: false)
+
+        get staff_pets_url, params: {q: {published_eq: "false"}}
+        assert_response :success
+
+        assert_equal 2, assigns[:pets].count
+        assert_equal 2, assigns[:pets].count { |pet| !pet.published }
+      end
     end
 
     context "#new" do


### PR DESCRIPTION
# 🔗 Issue
#795 

# ✍️ Description
- Added filters for application_paused, published, and placement_type in the staff pets view.
- Changed text in filter from "Unadopted" to "Not adopted"
- Added controller tests
- Moved ransack logic on Pet model to concern

# 📷 Screenshots/Demos
Short demo of new filters: 
[screencast2.webm](https://github.com/user-attachments/assets/79d8ccaf-f490-417c-bb5a-7a9ba1e0896e)

On mobile, the filters are taking up a lot of screen real estate, so if mobile is important could be improved in the future.
![Screenshot from 2024-10-08 14-06-26](https://github.com/user-attachments/assets/4904050e-74fe-4a78-8d0a-7781854ab35b)

# Questions
1. For the `placement_type` filter, I wasn't sure if this should just be a simple filter like I have implemented here, or if it should be something more. Because right now it seems confusing that you can have a pet that has already been adopted, but it will show up under "Adoptable" for Placement Type. Is this the expected behavior?