### PR TITLE
1021 Refactor Pet instance method to use the Match model instead of the AdopterApplication model

### DIFF
--- a/app/controllers/organizations/adoptable_pets_controller.rb
+++ b/app/controllers/organizations/adoptable_pets_controller.rb
@@ -8,10 +8,9 @@ class Organizations::AdoptablePetsController < Organizations::BaseController
   helper_method :get_animals
 
   def index
-    @q = authorized_scope(Pet.includes(:adopter_applications, images_attachments: :blob),
-      with: Organizations::AdoptablePetPolicy).ransack(params[:q])
+    @q = authorized_scope(Pet.all, with: Organizations::AdoptablePetPolicy).ransack(params[:q])
     @pagy, paginated_adoptable_pets = pagy(
-      @q.result,
+      @q.result.includes(:adopter_applications, :matches, images_attachments: :blob),
       limit: 9
     )
     @pets = paginated_adoptable_pets

--- a/app/controllers/organizations/adoptable_pets_controller.rb
+++ b/app/controllers/organizations/adoptable_pets_controller.rb
@@ -8,7 +8,7 @@ class Organizations::AdoptablePetsController < Organizations::BaseController
   helper_method :get_animals
 
   def index
-    @q = authorized_scope(Pet.all, with: Organizations::AdoptablePetPolicy).ransack(params[:q])
+    @q = authorized_scope(Pet.unadopted, with: Organizations::AdoptablePetPolicy).ransack(params[:q])
     @pagy, paginated_adoptable_pets = pagy(
       @q.result.includes(:adopter_applications, :matches, images_attachments: :blob),
       limit: 9

--- a/app/controllers/organizations/adopter_fosterer/likes_controller.rb
+++ b/app/controllers/organizations/adopter_fosterer/likes_controller.rb
@@ -9,7 +9,7 @@ class Organizations::AdopterFosterer::LikesController < Organizations::BaseContr
 
     likes = current_user.person.likes
     @likes_by_id = likes.index_by(&:pet_id)
-    @pets = current_user.person.liked_pets
+    @pets = current_user.person.liked_pets.includes(:matches, :adopter_applications, images_attachments: :blob)
   end
 
   def create

--- a/app/controllers/organizations/staff/pets_controller.rb
+++ b/app/controllers/organizations/staff/pets_controller.rb
@@ -8,7 +8,10 @@ class Organizations::Staff::PetsController < Organizations::BaseController
     authorize! Pet, context: {organization: Current.organization}
 
     @q = Pet.ransack(params[:q])
-    @pagy, @pets = pagy(authorized_scope(@q.result), limit: 10)
+    @pagy, @pets = pagy(
+      authorized_scope(@q.result.includes(:matches, :adopter_applications).with_attached_images),
+      limit: 10
+    )
   end
 
   def new

--- a/app/controllers/organizations/staff/pets_controller.rb
+++ b/app/controllers/organizations/staff/pets_controller.rb
@@ -9,7 +9,7 @@ class Organizations::Staff::PetsController < Organizations::BaseController
 
     @q = Pet.ransack(params[:q])
     @pagy, @pets = pagy(
-      authorized_scope(@q.result.includes(:matches, :adopter_applications).with_attached_images),
+      authorized_scope(@q.result.includes(:matches, :adopter_applications, images_attachments: :blob)),
       limit: 10
     )
   end

--- a/app/models/concerns/pet_ransackable.rb
+++ b/app/models/concerns/pet_ransackable.rb
@@ -7,7 +7,7 @@ module PetRansackable
     end
 
     def ransackable_associations(auth_object = nil)
-      ["adopter_applications"]
+      ["adopter_applications", "matches"]
     end
 
     def ransackable_scopes(auth_object = nil)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -97,7 +97,7 @@ class Pet < ApplicationRecord
   end
 
   def is_adopted?
-    adopter_applications.any? { |app| app.status == "adoption_made" }
+    matches.any? { |match| match.match_type == "adoption" }
   end
 
   def in_foster?

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -97,11 +97,19 @@ class Pet < ApplicationRecord
   end
 
   def is_adopted?
-    matches.any? { |match| match.match_type == "adoption" }
+    if matches.loaded?
+      matches.any? { |m| m.match_type == "adoption" }
+    else
+      matches.adoption.any?
+    end
   end
 
   def in_foster?
-    matches.in_foster.exists?
+    if matches.loaded?
+      matches.any? { |m| m.match_type == "foster" && (m.start_date..m.end_date).cover?(Time.now.utc) }
+    else
+      matches.in_foster.any?
+    end
   end
 
   def open?

--- a/test/controllers/organizations/adoptable_pets_controller_test.rb
+++ b/test/controllers/organizations/adoptable_pets_controller_test.rb
@@ -16,6 +16,16 @@ class Organizations::AdoptablePetsControllerTest < ActionDispatch::IntegrationTe
         get adoptable_pets_url
       end
     end
+
+    should "assign only unadopted pets" do
+      adopted_pet = create(:pet, :adopted)
+
+      get adoptable_pets_url
+
+      assert_response :success
+      assert_equal 1, assigns[:pets].count
+      assert assigns[:pets].pluck(:id).exclude?(adopted_pet.id)
+    end
   end
 
   context "#show" do

--- a/test/factories/matches.rb
+++ b/test/factories/matches.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
       start_date { Faker::Time.between(from: 1.year.ago, to: 1.month.from_now) }
       end_date { start_date + rand(3..6).months }
     end
+
+    trait :adoption do
+      match_type { :adoption }
+      start_date { Faker::Time.between(from: 1.year.ago, to: 1.day.ago) }
+      end_date { 1.day.from_now }
+    end
   end
 end

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -98,13 +98,12 @@ class PetTest < ActiveSupport::TestCase
   end
 
   context "#is_adopted?" do
-    should "return true if there is an adopter application with 'adoption_pending' status" do
+    should "return true if there is a match with 'adoption' match_type" do
       pet = Pet.new
-      adopter_application = pet.adopter_applications.new
-      adopter_application.status = "adoption_made"
+      match = pet.matches.new(match_type: "adoption")
       assert pet.is_adopted?
 
-      adopter_application.status = "awaiting_review"
+      match.match_type = "foster"
       assert_not pet.is_adopted?
     end
   end

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -99,12 +99,23 @@ class PetTest < ActiveSupport::TestCase
 
   context "#is_adopted?" do
     should "return true if there is a match with 'adoption' match_type" do
-      pet = Pet.new
-      match = pet.matches.new(match_type: "adoption")
+      pet = create(:pet)
+      match = create(:match, :adoption, pet:)
       assert pet.is_adopted?
 
-      match.match_type = "foster"
+      match.update(match_type: "foster")
       assert_not pet.is_adopted?
+    end
+  end
+
+  context "#in_foster?" do
+    should "return true if there is a match with 'foster' match_type" do
+      pet = create(:pet)
+      match = create(:foster, pet:, start_date: 1.month.ago, end_date: 1.day.from_now)
+      assert pet.in_foster?
+
+      match.update(match_type: "adoption")
+      assert_not pet.in_foster?
     end
   end
 


### PR DESCRIPTION
# 🔗 Issue
#1021 

# ✍️ Description
- Refactored `Pet#is_adopted?` method to reference `Match` association rather than `AdopterApplication`
- Fixed related tests
