### PR TITLE
1421 - Verify and fix Google Omniauth flow

### DIFF
--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -7,10 +7,12 @@ module Omniauthable
 
   class_methods do
     def from_omniauth(auth)
-      where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-        user.assign_attributes_from_auth(auth)
-        user.set_adopter_role
+      user = where(provider: auth.provider, uid: auth.uid).first_or_create do |u|
+        u.assign_attributes_from_auth(auth)
       end
+
+      user.set_adopter_role if user.persisted?
+      user
     end
   end
 


### PR DESCRIPTION
# 🔗 Issue
#1421 

# ✍️ Description
- Current implementation was giving issue when we try to sign in with same google user for different organization as user_id was not getting mapped in database table for person table so flow was getting stuck in new person page. It was not allowing user to even logout due to error.
- Have fixed issue by moving people creation flow outside user loop as issue with previous implementation was that person and its group was getting created in database before user was created when user first time sign up using google login.


# 📷 Screenshots/Demos

[Alta Pet Rescue _ google_onmiauth.webm](https://github.com/user-attachments/assets/0ae2ba42-7b65-4977-9724-1a7e2301ced3)

