### PR TITLE
Whitelisted Users::SessionsController#destroy for verify_person_in_org filter

### DIFF
--- a/app/controllers/concerns/organization_scopable.rb
+++ b/app/controllers/concerns/organization_scopable.rb
@@ -4,7 +4,7 @@ module OrganizationScopable
   included do
     set_current_tenant_through_filter
     before_action :set_tenant
-    before_action :verify_person_in_org, unless: -> { is_a?(Users::SessionsController) && action_name == "destroy" }
+    before_action :verify_person_in_org
     # Add current person context to policies
     authorize :person, through: -> { Current.person }
   end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,4 +3,6 @@
 class Users::SessionsController < Devise::SessionsController
   include OrganizationScopable
   layout "application"
+
+  skip_before_action :verify_person_in_org, only: :destroy
 end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
https://github.com/rubyforgood/homeward-tails/issues/1422

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
I have whitelisted the  Users::SessionsController#destroy for the verify_person_in_org filter in Organizations Scopable.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

https://github.com/user-attachments/assets/f3bb14dc-4c96-447e-b961-b74346d49992

I have logged in as adopter1@alta.com and signed out from baja new page.
