### PR TITLE
1464 - Staff Pet Show > wrap the tabs on mobile so I do not have to scroll to see all tabs

### DIFF
--- a/app/components/dashboard_page_component.html.erb
+++ b/app/components/dashboard_page_component.html.erb
@@ -26,7 +26,7 @@
     <!-- Nav tabs -->
     <div class="row">
       <div class="col-12">
-          <ul class="nav nav-lb-tab mt-n3 gap-1">
+          <ul class="nav nav-lb-tab mt-n3 gap-1 flex-wrap">
             <%# nav_tabs %>
             <% nav_tabs.each do |tab| %>
               <%= tab %>


### PR DESCRIPTION

# 🔗 Issue
https://github.com/rubyforgood/homeward-tails/issues/1464

# ✍️ Description
1.  Update dashboard page component to allow flexible tab layout by adding flex-wrap.

# 📷 Screenshots/Demos

[Screencast from 15-07-25 01:29:24 AM IST.webm](https://github.com/user-attachments/assets/454687d9-eeb7-4e00-b37f-9585814ab9b8)
