### PR TITLE
Fix boostrap_form assets

### DIFF
--- a/config/dartsass.rb
+++ b/config/dartsass.rb
@@ -1,1 +1,0 @@
-Rails.application.config.dartsass.load_paths << Bundler.rubygems.find_name("bootstrap_form").first.full_gem_path + "/app/assets/stylesheets"


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
The bootstrap_form gem includes a css file that is not being loaded correctly.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
<img width="2878" height="1689" alt="Screenshot from 2025-07-24 17-36-48" src="https://github.com/user-attachments/assets/ecf17eb8-2ebe-4073-93c6-e0dcc55c32e2" />
