### PR TITLE
Fixed 1425 DashBoard and Admin Links not visible on navbar when visit…

### DIFF
--- a/app/controllers/organizations/donate_controller.rb
+++ b/app/controllers/organizations/donate_controller.rb
@@ -1,0 +1,8 @@
+module Organizations
+  class DonateController < Organizations::BaseController
+    skip_before_action :authenticate_user!
+    skip_verify_authorized only: %i[index]
+    def index
+    end
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,7 +4,6 @@ class StaticPagesController < ApplicationController
   skip_verify_authorized only: %i[
     about_us
     cookie_policy
-    donate
     partners
     privacy_policy
     terms_and_conditions
@@ -23,9 +22,6 @@ class StaticPagesController < ApplicationController
   end
 
   def partners
-  end
-
-  def donate
   end
 
   def privacy_policy

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -75,7 +75,7 @@
           <%= active_link_to t(".contact"), new_contact_path, class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= active_link_to t(".donate"), donate_path, class: "nav-link" %>
+          <%= active_link_to t(".donate"), donate_index_path, class: "nav-link" %>
         </li>
         <li class="nav-item">
           <%= active_link_to t(".faq"), faq_index_path, class: "nav-link" %>

--- a/app/views/organizations/donate/index.html.erb
+++ b/app/views/organizations/donate/index.html.erb
@@ -1,0 +1,1 @@
+<%= render "static_pages/donate_content" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Rails.application.routes.draw do
   get "/up", to: "root#up" # Health check endpoint to let Kamal know the app is up
   get "/about_us", to: "static_pages#about_us"
   get "/partners", to: "static_pages#partners"
-  get "/donate", to: "static_pages#donate"
   get "/privacy_policy", to: "static_pages#privacy_policy"
   get "/terms_and_conditions", to: "static_pages#terms_and_conditions"
   get "/cookie_policy", to: "static_pages#cookie_policy"
@@ -37,6 +36,7 @@ Rails.application.routes.draw do
     resources :people, only: %i[new create edit update]
     resources :contacts, only: %i[new create]
     resources :accounts, only: %i[show]
+    resources :donate, only: [:index]
 
     # Staff Routes
     namespace :staff do

--- a/test/controllers/organizations/donate_controller_test.rb
+++ b/test/controllers/organizations/donate_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class Organization::DonateControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Current.organization = create(:organization)
+
+    @admin = create(:person, :admin)
+
+    @adopter = create(:person, :adopter)
+  end
+
+  context "Donate Page" do
+    should "accessible to unauthenticated users" do
+      get donate_index_path
+      assert_response :success
+      assert_select "h1", /Give them/
+    end
+
+    should "shows Admin link in navbar for admin users" do
+      sign_in @admin.user
+      get donate_index_path
+      assert_response :success
+      assert_select "nav", /Admin/
+    end
+
+    should "shows Dashboard link in navbar for adopter/fosterer users" do
+      sign_in @adopter.user
+      get donate_index_path
+      assert_response :success
+      assert_select "nav", /Dashboard/
+    end
+  end
+end

--- a/test/integration/static_pages_test.rb
+++ b/test/integration/static_pages_test.rb
@@ -15,13 +15,6 @@ class StaticPagesTest < ActionDispatch::IntegrationTest
     # assert_select "h1", "Frequently Asked Questions"
   end
 
-  test "Donate page can be accessed" do
-    skip("while new ui is implemented")
-    # get "/donate"
-    # assert_response :success
-    # assert_select "h1", "Donate"
-  end
-
   test "Contact Us page can be accessed" do
     skip("while new ui is implemented")
     # get "/contacts/new"


### PR DESCRIPTION
Donate Page

# 🔗 Issue
#1425 

# ✍️ Description
Dashboard and Admin dashboard links were not shown on navabr when accessed donate in authenticated state.
Donate was in static page controller, which was leading to failed check for organization dashboard policy. Moved Donate page under organization scopable.

# 📷 Screenshots/Demos
<img width="1440" height="586" alt="Screenshot 2025-07-28 at 10 45 00 AM" src="https://github.com/user-attachments/assets/90e6d125-3a97-4fd6-8aaf-ea9c4875b916" />

